### PR TITLE
Generate migrations warning free on Rails 5

### DIFF
--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -59,6 +59,14 @@ module Fx
           end
         end
 
+        def activerecord_migration_class
+          if ActiveRecord::Migration.respond_to?(:current_version)
+            "ActiveRecord::Migration[5.0]"
+          else
+            "ActiveRecord::Migration"
+          end
+        end
+
         def formatted_name
           if singular_name.include?(".")
             "\"#{singular_name}\""

--- a/lib/generators/fx/function/templates/db/migrate/create_function.erb
+++ b/lib/generators/fx/function/templates/db/migrate/create_function.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
     create_function <%= formatted_name %>
   end

--- a/lib/generators/fx/function/templates/db/migrate/update_function.erb
+++ b/lib/generators/fx/function/templates/db/migrate/update_function.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
     update_function <%= formatted_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   end

--- a/lib/generators/fx/trigger/templates/db/migrate/create_trigger.erb
+++ b/lib/generators/fx/trigger/templates/db/migrate/create_trigger.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
     create_trigger <%= formatted_name %>, on: <%= formatted_table_name %>
   end

--- a/lib/generators/fx/trigger/templates/db/migrate/update_trigger.erb
+++ b/lib/generators/fx/trigger/templates/db/migrate/update_trigger.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
     update_trigger <%= formatted_name %>, on: <%= formatted_table_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   end

--- a/lib/generators/fx/trigger/trigger_generator.rb
+++ b/lib/generators/fx/trigger/trigger_generator.rb
@@ -56,6 +56,14 @@ module Fx
           end
         end
 
+        def activerecord_migration_class
+          if ActiveRecord::Migration.respond_to?(:current_version)
+            "ActiveRecord::Migration[5.0]"
+          else
+            "ActiveRecord::Migration"
+          end
+        end
+
         def formatted_name
           if singular_name.include?(".")
             "\"#{singular_name}\""


### PR DESCRIPTION
Rails 5 introduced versioned migrations to cope with breaking changes in
the migrations API. To remedy those breakages, versioned migrations were
introduced.

The new migration syntax is only generated on Rails 5.0 and above.