### PR TITLE
Order triggers and functions by Postgres oid

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -17,7 +17,8 @@ module Fx
               ON pn.oid = pp.pronamespace
           LEFT JOIN pg_depend pd
               ON pd.objid = pp.oid AND pd.deptype = 'e'
-          WHERE pn.nspname = 'public' AND pd.objid IS NULL;
+          WHERE pn.nspname = 'public' AND pd.objid IS NULL
+          ORDER BY pp.oid;
         SQL
 
         # Wraps #all as a static facade.

--- a/lib/fx/adapters/postgres/triggers.rb
+++ b/lib/fx/adapters/postgres/triggers.rb
@@ -18,7 +18,8 @@ module Fx
           JOIN pg_proc pp
               ON (pp.oid = pt.tgfoid)
           WHERE pt.tgname
-          NOT ILIKE '%constraint%' AND pt.tgname NOT ILIKE 'pg%';
+          NOT ILIKE '%constraint%' AND pt.tgname NOT ILIKE 'pg%'
+          ORDER BY pc.oid;
         SQL
 
         # Wraps #all as a static facade.


### PR DESCRIPTION
Our previous strategy of relying on postgres to give us the
triggers/functions in the correct order was incorrect.
Those tables have no specific ordering so the results can come back in
any order.

Ordering by 'oid' is the simplest way to order everything by insertion
order. Dropping a view that depends on a child view also requires
dropping that child view, so ordering in this manner should be
sufficient.