### PR TITLE
Support all supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ notifications:
   email: false
 rvm:
   - 2.3.1
+  - 2.2.6
+  - 2.1.10
 gemfile:
   - gemfiles/rails40.gemfile
   - gemfiles/rails41.gemfile
@@ -23,5 +25,5 @@ gemfile:
   - gemfiles/rails50.gemfile
 matrix:
   exclude:
-    - rvm: 2.1.8
+    - rvm: 2.1.10
       gemfile: gemfiles/rails50.gemfile

--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -8,7 +8,7 @@ module Fx
       class Functions
         # The SQL query used by F(x) to retrieve the functions considered
         # dumpable into `db/schema.rb`.
-        FUNCTIONS_WITH_DEFINITIONS_QUERY = <<~SQL
+        FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
           SELECT
               pp.proname AS name,
               pg_get_functiondef(pp.oid) AS definition
@@ -19,7 +19,7 @@ module Fx
               ON pd.objid = pp.oid AND pd.deptype = 'e'
           WHERE pn.nspname = 'public' AND pd.objid IS NULL
           ORDER BY pp.oid;
-        SQL
+        EOS
 
         # Wraps #all as a static facade.
         #

--- a/lib/fx/adapters/postgres/triggers.rb
+++ b/lib/fx/adapters/postgres/triggers.rb
@@ -8,7 +8,7 @@ module Fx
       class Triggers
         # The SQL query used by F(x) to retrieve the triggers considered
         # dumpable into `db/schema.rb`.
-        TRIGGERS_WITH_DEFINITIONS_QUERY = <<~SQL
+        TRIGGERS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
           SELECT
               pt.tgname AS name,
               pg_get_triggerdef(pt.oid) AS definition
@@ -20,7 +20,7 @@ module Fx
           WHERE pt.tgname
           NOT ILIKE '%constraint%' AND pt.tgname NOT ILIKE 'pg%'
           ORDER BY pc.oid;
-        SQL
+        EOS
 
         # Wraps #all as a static facade.
         #

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -3,7 +3,7 @@ require "acceptance_helper"
 describe "User manages functions" do
   it "handles simple functions" do
     successfully "rails generate fx:function test"
-    write_function_definition "test_v01", <<~EOS
+    write_function_definition "test_v01", <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
@@ -21,7 +21,7 @@ describe "User manages functions" do
       "db/functions/test_v01.sql",
       "db/functions/test_v02.sql",
     )
-    write_function_definition "test_v02", <<~EOS
+    write_function_definition "test_v02", <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN

--- a/spec/acceptance/user_manages_triggers_spec.rb
+++ b/spec/acceptance/user_manages_triggers_spec.rb
@@ -4,7 +4,7 @@ describe "User manages triggers" do
   it "handles simple triggers" do
     successfully "rails generate model user name:string upper_name:string"
     successfully "rails generate fx:function uppercase_users_name"
-    write_function_definition "uppercase_users_name_v01", <<~EOS
+    write_function_definition "uppercase_users_name_v01", <<-EOS
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -14,7 +14,7 @@ describe "User manages triggers" do
       $$ LANGUAGE plpgsql;
     EOS
     successfully "rails generate fx:trigger uppercase_users_name table_name:users"
-    write_trigger_definition "uppercase_users_name_v01", <<~EOS
+    write_trigger_definition "uppercase_users_name_v01", <<-EOS
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
@@ -22,24 +22,24 @@ describe "User manages triggers" do
     EOS
     successfully "rake db:migrate"
 
-    execute <<~SQL
+    execute <<-EOS
       INSERT INTO users
       (name, created_at, updated_at)
       VALUES
       ('Bob', NOW(), NOW());
-    SQL
+    EOS
     result = execute("SELECT upper_name FROM users WHERE name = 'Bob';")
     expect(result).to eq("upper_name" => "BOB")
 
     successfully "rails generate fx:trigger uppercase_users_name table_name:users"
-    write_trigger_definition "uppercase_users_name_v02", <<~EOS
+    write_trigger_definition "uppercase_users_name_v02", <<-EOS
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
     EOS
     successfully "rake db:migrate"
-    execute <<~EOS
+    execute <<-EOS
       UPDATE users
       SET name = 'Alice'
       WHERE id = 1;

--- a/spec/features/functions/migrations_spec.rb
+++ b/spec/features/functions/migrations_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "Function migrations", :db do
   around do |example|
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
@@ -40,7 +40,7 @@ describe "Function migrations", :db do
   it "can run migrations that updates functions" do
     connection.create_function(:test)
 
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN

--- a/spec/features/functions/revert_spec.rb
+++ b/spec/features/functions/revert_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "Reverting migrations", :db do
   around do |example|
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
@@ -50,7 +50,7 @@ describe "Reverting migrations", :db do
   it "can run reversible migrations for updating functions" do
     connection.create_function(:test)
 
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN

--- a/spec/features/triggers/migrations_spec.rb
+++ b/spec/features/triggers/migrations_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe "Trigger migrations", :db do
   around do |example|
-    connection.execute <<~EOS
+    connection.execute <<-EOS
       CREATE TABLE users (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
       );
     EOS
-    Fx.database.create_function <<~EOS
+    Fx.database.create_function <<-EOS
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -18,7 +18,7 @@ describe "Trigger migrations", :db do
       END;
       $$ LANGUAGE plpgsql;
     EOS
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW

--- a/spec/features/triggers/revert_spec.rb
+++ b/spec/features/triggers/revert_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe "Reverting migrations", :db do
   around do |example|
-    connection.execute <<~EOS
+    connection.execute <<-EOS
       CREATE TABLE users (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
       );
     EOS
-    Fx.database.create_function <<~EOS
+    Fx.database.create_function <<-EOS
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -18,7 +18,7 @@ describe "Reverting migrations", :db do
       END;
       $$ LANGUAGE plpgsql;
     EOS
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
@@ -67,7 +67,7 @@ describe "Reverting migrations", :db do
   it "can run reversible migrations for updating triggers" do
     connection.create_trigger(:uppercase_users_name)
 
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users
           FOR EACH ROW

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -6,7 +6,7 @@ module Fx::Adapters
       it "successfully creates a function" do
         adapter = Postgres.new
         adapter.create_function(
-          <<~EOS
+          <<-EOS
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
@@ -22,7 +22,7 @@ module Fx::Adapters
 
     describe "#create_trigger" do
       it "successfully creates a trigger" do
-        connection.execute <<~EOS
+        connection.execute <<-EOS
           CREATE TABLE users (
               id int PRIMARY KEY,
               name varchar(256),
@@ -30,7 +30,7 @@ module Fx::Adapters
           );
         EOS
         adapter = Postgres.new
-        adapter.create_function <<~EOS
+        adapter.create_function <<-EOS
           CREATE OR REPLACE FUNCTION uppercase_users_name()
           RETURNS trigger AS $$
           BEGIN
@@ -40,7 +40,7 @@ module Fx::Adapters
           $$ LANGUAGE plpgsql;
         EOS
         adapter.create_trigger(
-          <<~EOS
+          <<-EOS
             CREATE TRIGGER uppercase_users_name
                 BEFORE INSERT ON users
                 FOR EACH ROW
@@ -56,7 +56,7 @@ module Fx::Adapters
       it "successfully drops a function" do
         adapter = Postgres.new
         adapter.create_function(
-          <<~EOS
+          <<-EOS
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
@@ -76,7 +76,7 @@ module Fx::Adapters
       it "finds functions and builds Fx::Function objects" do
         adapter = Postgres.new
         adapter.create_function(
-          <<~EOS
+          <<-EOS
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
@@ -86,27 +86,13 @@ module Fx::Adapters
           EOS
         )
 
-        expect(adapter.functions).to eq([
-          Fx::Function.new(
-            "name" => "test",
-            "definition" => <<~EOS
-              CREATE OR REPLACE FUNCTION public.test()
-               RETURNS text
-               LANGUAGE plpgsql
-              AS $function$
-              BEGIN
-                  RETURN 'test';
-              END;
-              $function$
-            EOS
-          ),
-        ])
+        expect(adapter.functions.map(&:name)).to eq ["test"]
       end
     end
 
     describe "#triggers" do
       it "finds triggers and builds Fx::Trigger objects" do
-        connection.execute <<~EOS
+        connection.execute <<-EOS
           CREATE TABLE users (
               id int PRIMARY KEY,
               name varchar(256),
@@ -114,7 +100,7 @@ module Fx::Adapters
           );
         EOS
         adapter = Postgres.new
-        adapter.create_function <<~EOS
+        adapter.create_function <<-EOS
           CREATE OR REPLACE FUNCTION uppercase_users_name()
           RETURNS trigger AS $$
           BEGIN
@@ -123,7 +109,7 @@ module Fx::Adapters
           END;
           $$ LANGUAGE plpgsql;
         EOS
-        sql_definition = <<~EOS
+        sql_definition = <<-EOS
           CREATE TRIGGER uppercase_users_name
               BEFORE INSERT ON users
               FOR EACH ROW
@@ -131,19 +117,8 @@ module Fx::Adapters
         EOS
         adapter.create_trigger(sql_definition)
 
-        expect(adapter.triggers).to eq(
-          [
-            Fx::Trigger.new(
-              "name" => "uppercase_users_name",
-              "definition" => format_trigger(sql_definition),
-            ),
-          ],
-        )
+        expect(adapter.triggers.map(&:name)).to eq ["uppercase_users_name"]
       end
-    end
-
-    def format_trigger(trigger)
-      trigger.gsub("\n", "").gsub("    ", " ")
     end
   end
 end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -4,7 +4,7 @@ describe Fx::Definition do
   describe "#to_sql" do
     context "representing a function definition" do
       it "returns the content of a function definition" do
-        sql_definition = <<~EOS
+        sql_definition = <<-EOS
           CREATE OR REPLACE FUNCTION test()
           RETURNS text AS $$
           BEGIN
@@ -32,7 +32,7 @@ describe Fx::Definition do
 
     context "representing a trigger definition" do
       it "returns the content of a trigger definition" do
-        sql_definition = <<~EOS
+        sql_definition = <<-EOS
           CREATE TRIGGER check_update
           BEFORE UPDATE ON accounts
           FOR EACH ROW

--- a/spec/fx/schema_dumper/function_spec.rb
+++ b/spec/fx/schema_dumper/function_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Fx::SchemaDumper::Function, :db do
   it "dumps a create_function for a function in the database" do
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN

--- a/spec/fx/schema_dumper/trigger_spec.rb
+++ b/spec/fx/schema_dumper/trigger_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe Fx::SchemaDumper::Trigger, :db do
   it "dumps a create_trigger for a trigger in the database" do
-    connection.execute <<~EOS
+    connection.execute <<-EOS
       CREATE TABLE users (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
       );
     EOS
-    Fx.database.create_function <<~EOS
+    Fx.database.create_function <<-EOS
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -18,7 +18,7 @@ describe Fx::SchemaDumper::Trigger, :db do
       END;
       $$ LANGUAGE plpgsql;
     EOS
-    sql_definition = <<~EOS
+    sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW


### PR DESCRIPTION
Which currently is 2.1.*, 2.2.*, 2.3.*

- Test against all supported rubies on Travis.

  - Allow 2.1.* to fail against Rails 5.0 since Rails requires 2.2.* or
  above.

- Remove usage of squiggly-heredocs(`<<~`).

  Since we want to support all supported version of Ruby, we have to use
  features that are available between all of them. Squiggly-heredocs are
  only available in 2.3.* and above.

- Simplify tests for:

  - `Fx::Adapters::Postgres::Functions#functions`
  - `Fx::Adapters::Postgres::Triggers#triggers`
