### PR TITLE
Support functions with parameters

### DIFF
--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -125,7 +125,7 @@ module Fx
       #
       # @return [void]
       def drop_function(name)
-        execute "DROP FUNCTION #{name}();"
+        execute "DROP FUNCTION #{name}(#{arguments_for_function(name)});"
       end
 
       # Drops the trigger from the database
@@ -149,6 +149,18 @@ module Fx
 
       def connection
         Connection.new(connectable.connection)
+      end
+
+      def arguments_for_function(name)
+        arguments = execute <<-EOS
+          WITH func_oid AS (
+              SELECT oid FROM pg_proc
+              WHERE proname = '#{name}'
+          )
+          SELECT * FROM
+          pg_get_function_identity_arguments((SELECT oid FROM func_oid));
+        EOS
+        arguments[0]["pg_get_function_identity_arguments"]
       end
     end
   end

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -34,4 +34,23 @@ describe "User manages functions" do
     result = execute("SELECT * FROM test() AS result")
     expect(result).to eq("result" => "testest")
   end
+
+  it "handles functions with arguments" do
+    successfully "rails generate fx:function adder"
+    write_function_definition "adder_v01", <<-EOS
+      CREATE FUNCTION adder(x int, y int)
+      RETURNS int AS $$
+      BEGIN
+          RETURN $1 + $2;
+      END;
+      $$ LANGUAGE plpgsql;
+    EOS
+    successfully "rake db:migrate"
+
+    result = execute("SELECT * FROM adder(1, 2) AS result")
+    expect(result).to eq("result" => 3)
+
+    successfully "rails destroy fx:function adder"
+    successfully "rake db:migrate"
+  end
 end

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -53,22 +53,44 @@ module Fx::Adapters
     end
 
     describe "#drop_function" do
-      it "successfully drops a function" do
-        adapter = Postgres.new
-        adapter.create_function(
-          <<-EOS
-            CREATE OR REPLACE FUNCTION test()
-            RETURNS text AS $$
-            BEGIN
-                RETURN 'test';
-            END;
-            $$ LANGUAGE plpgsql;
-          EOS
-        )
+      context "when the function has arguments" do
+        it "successfully drops a function with the entire function signature" do
+          adapter = Postgres.new
+          adapter.create_function(
+            <<-EOS
+              CREATE FUNCTION adder(x int, y int)
+              RETURNS int AS $$
+              BEGIN
+                  RETURN $1 + $2;
+              END;
+              $$ LANGUAGE plpgsql;
+            EOS
+          )
 
-        adapter.drop_function(:test)
+          adapter.drop_function(:adder)
 
-        expect(adapter.functions.map(&:name)).not_to include("test")
+          expect(adapter.functions.map(&:name)).not_to include("adder")
+        end
+      end
+
+      context "when the function does not have arguments" do
+        it "successfully drops a function" do
+          adapter = Postgres.new
+          adapter.create_function(
+            <<-EOS
+              CREATE OR REPLACE FUNCTION test()
+              RETURNS text AS $$
+              BEGIN
+                  RETURN 'test';
+              END;
+              $$ LANGUAGE plpgsql;
+            EOS
+          )
+
+          adapter.drop_function(:test)
+
+          expect(adapter.functions.map(&:name)).not_to include("test")
+        end
       end
     end
 


### PR DESCRIPTION
When dropping a function, the entire function signature must be present.
Which includes the types of the parameters the function uses.

This PR changes `drop_function` to perform a lookup on what are the
function parameters and their respective types.