### PR TITLE
Fix test suite issues

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -21,11 +21,6 @@ if RUBY_VERSION > "2.2.0"
 
   appraise "rails-edge" do
     gem "rails", github: "rails/rails"
-    gem "rspec-rails", github: "rspec/rspec-rails"
-    gem "rspec-support", github: "rspec/rspec-support"
-    gem "rspec-core", github: "rspec/rspec-core"
-    gem "rspec-mocks", github: "rspec/rspec-mocks"
-    gem "rspec-expectations", github: "rspec/rspec-expectations"
-    gem "rspec", github: "rspec/rspec"
+    gem "arel", :github => "rails/arel"
   end
 end

--- a/bin/setup
+++ b/bin/setup
@@ -9,4 +9,5 @@ if [ -z "$CI" ]; then
   bundle exec appraisal install
 fi
 
+bundle exec rake dummy:db:drop
 bundle exec rake dummy:db:create

--- a/gemfiles/rails40.gemfile.lock
+++ b/gemfiles/rails40.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
     fx (0.3.0)
       activerecord (>= 4.0.0)
@@ -41,7 +41,7 @@ GEM
     builder (3.1.4)
     coderay (1.1.1)
     database_cleaner (1.5.3)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     erubis (2.7.0)
     i18n (0.7.0)
     method_source (0.8.2)
@@ -60,8 +60,8 @@ GEM
       activesupport (= 4.0.13)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.3.0)
-    redcarpet (3.3.4)
+    rake (12.0.0)
+    redcarpet (3.4.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -84,10 +84,10 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (0.3.52)
-    yard (0.9.5)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -108,4 +108,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/gemfiles/rails41.gemfile.lock
+++ b/gemfiles/rails41.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
     fx (0.3.0)
       activerecord (>= 4.0.0)
@@ -39,15 +39,15 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (5.0.1.20140414130214)
-    builder (3.2.2)
+    builder (3.2.3)
     coderay (1.1.1)
     database_cleaner (1.5.3)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     erubis (2.7.0)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     method_source (0.8.2)
-    minitest (5.9.1)
+    minitest (5.10.1)
     pg (0.19.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -61,8 +61,8 @@ GEM
       activesupport (= 4.1.16)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.3.0)
-    redcarpet (3.3.4)
+    rake (12.0.0)
+    redcarpet (3.4.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -85,11 +85,11 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yard (0.9.5)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -110,4 +110,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/gemfiles/rails42.gemfile.lock
+++ b/gemfiles/rails42.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
     fx (0.3.0)
       activerecord (>= 4.0.0)
@@ -42,20 +42,20 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    arel (6.0.3)
-    builder (3.2.2)
+    arel (6.0.4)
+    builder (3.2.3)
     coderay (1.1.1)
     database_cleaner (1.5.3)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     erubis (2.7.0)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
-    nokogiri (1.6.8.1)
+    minitest (5.10.1)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     pg (0.19.0)
     pry (0.10.4)
@@ -67,9 +67,9 @@ GEM
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
@@ -78,8 +78,8 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.3.0)
-    redcarpet (3.3.4)
+    rake (12.0.0)
+    redcarpet (3.4.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -102,11 +102,11 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yard (0.9.5)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -127,4 +127,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
     fx (0.3.0)
       activerecord (>= 4.0.0)
@@ -8,26 +8,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.0.0.1)
-      actionview (= 5.0.0.1)
-      activesupport (= 5.0.0.1)
+    actionpack (5.0.1)
+      actionview (= 5.0.1)
+      activesupport (= 5.0.1)
       rack (~> 2.0)
       rack-test (~> 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.0.0.1)
-      activesupport (= 5.0.0.1)
+    actionview (5.0.1)
+      activesupport (= 5.0.1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activemodel (5.0.0.1)
-      activesupport (= 5.0.0.1)
-    activerecord (5.0.0.1)
-      activemodel (= 5.0.0.1)
-      activesupport (= 5.0.0.1)
+    activemodel (5.0.1)
+      activesupport (= 5.0.1)
+    activerecord (5.0.1)
+      activemodel (= 5.0.1)
+      activesupport (= 5.0.1)
       arel (~> 7.0)
-    activesupport (5.0.0.1)
+    activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -41,19 +41,19 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (7.1.4)
-    builder (3.2.2)
+    builder (3.2.3)
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     database_cleaner (1.5.3)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     erubis (2.7.0)
     i18n (0.7.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
-    nokogiri (1.6.8.1)
+    minitest (5.10.1)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     pg (0.19.0)
     pry (0.10.4)
@@ -63,19 +63,19 @@ GEM
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails-dom-testing (2.0.1)
+    rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    railties (5.0.0.1)
-      actionpack (= 5.0.0.1)
-      activesupport (= 5.0.0.1)
+    railties (5.0.1)
+      actionpack (= 5.0.1)
+      activesupport (= 5.0.1)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.3.0)
-    redcarpet (3.3.4)
+    rake (12.0.0)
+    redcarpet (3.4.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -98,11 +98,11 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yard (0.9.5)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -123,4 +123,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,11 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", :github => "rails/rails"
-gem "rspec-rails", :github => "rspec/rspec-rails"
-gem "rspec-support", :github => "rspec/rspec-support"
-gem "rspec-core", :github => "rspec/rspec-core"
-gem "rspec-mocks", :github => "rspec/rspec-mocks"
-gem "rspec-expectations", :github => "rspec/rspec-expectations"
-gem "rspec", :github => "rspec/rspec"
+gem "arel", :github => "rails/arel"
 
 gemspec :path => "../"

--- a/gemfiles/rails_edge.gemfile.lock
+++ b/gemfiles/rails_edge.gemfile.lock
@@ -1,10 +1,16 @@
 GIT
+  remote: git://github.com/rails/arel.git
+  revision: f5f81be73df89011fe9bc89915b99d81e0c9a67f
+  specs:
+    arel (8.0.0)
+
+GIT
   remote: git://github.com/rails/rails.git
-  revision: 8dbc1ca339e63e00c8da0f0e74cd38ce507415b1
+  revision: 6a1c0218df1fcffaac97e7288db07934bfef277f
   specs:
     actioncable (5.1.0.alpha)
       actionpack (= 5.1.0.alpha)
-      nio4r (~> 1.2)
+      nio4r (~> 2.0)
       websocket-driver (~> 0.6.1)
     actionmailer (5.1.0.alpha)
       actionpack (= 5.1.0.alpha)
@@ -22,9 +28,9 @@ GIT
     actionview (5.1.0.alpha)
       activesupport (= 5.1.0.alpha)
       builder (~> 3.1)
-      erubis (~> 2.7.0)
+      erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     activejob (5.1.0.alpha)
       activesupport (= 5.1.0.alpha)
       globalid (>= 0.3.6)
@@ -33,7 +39,7 @@ GIT
     activerecord (5.1.0.alpha)
       activemodel (= 5.1.0.alpha)
       activesupport (= 5.1.0.alpha)
-      arel (~> 7.0)
+      arel (~> 8.0)
     activesupport (5.1.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -58,59 +64,8 @@ GIT
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
 
-GIT
-  remote: git://github.com/rspec/rspec-core.git
-  revision: 0c8db72445c21156757c8f1069aeca3c8c6841ed
-  specs:
-    rspec-core (3.6.0.beta1)
-      rspec-support (= 3.6.0.beta1)
-
-GIT
-  remote: git://github.com/rspec/rspec-expectations.git
-  revision: 40b61c44d7ce36bf59dd09c0d0094bb19a1c1f99
-  specs:
-    rspec-expectations (3.6.0.beta1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (= 3.6.0.beta1)
-
-GIT
-  remote: git://github.com/rspec/rspec-mocks.git
-  revision: 95269ec7c02cf494175a70829d5da56965608e17
-  specs:
-    rspec-mocks (3.6.0.beta1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (= 3.6.0.beta1)
-
-GIT
-  remote: git://github.com/rspec/rspec-rails.git
-  revision: ca780a36d0f41c03fd2692098508c49d50a0b994
-  specs:
-    rspec-rails (3.6.0.beta1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (= 3.6.0.beta1)
-      rspec-expectations (= 3.6.0.beta1)
-      rspec-mocks (= 3.6.0.beta1)
-      rspec-support (= 3.6.0.beta1)
-
-GIT
-  remote: git://github.com/rspec/rspec-support.git
-  revision: e1c547c7091066b0db26b17b0bd19278318816b0
-  specs:
-    rspec-support (3.6.0.beta1)
-
-GIT
-  remote: git://github.com/rspec/rspec.git
-  revision: bc209d4a2a2dfbf38ac1d470b213753aa9e654db
-  specs:
-    rspec (3.6.0.beta1)
-      rspec-core (= 3.6.0.beta1)
-      rspec-expectations (= 3.6.0.beta1)
-      rspec-mocks (= 3.6.0.beta1)
-
 PATH
-  remote: ../
+  remote: ..
   specs:
     fx (0.3.0)
       activerecord (>= 4.0.0)
@@ -127,13 +82,12 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    arel (7.1.4)
-    builder (3.2.2)
+    builder (3.2.3)
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     database_cleaner (1.5.3)
-    diff-lcs (1.2.5)
-    erubis (2.7.0)
+    diff-lcs (1.3)
+    erubi (1.5.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -146,9 +100,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
-    nio4r (1.2.1)
-    nokogiri (1.6.8.1)
+    minitest (5.10.1)
+    nio4r (2.0.0)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     pg (0.19.0)
     pry (0.10.4)
@@ -158,29 +112,50 @@ GEM
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails-dom-testing (2.0.1)
+    rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rake (11.3.0)
-    redcarpet (3.3.4)
+    rake (12.0.0)
+    redcarpet (3.4.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-rails (3.5.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     slop (3.6.0)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    websocket-driver (0.6.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    yard (0.9.5)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -188,6 +163,7 @@ PLATFORMS
 DEPENDENCIES
   ammeter (>= 1.1.3)
   appraisal
+  arel!
   bundler (>= 1.5)
   database_cleaner
   fx!
@@ -196,13 +172,8 @@ DEPENDENCIES
   rails!
   rake
   redcarpet
-  rspec!
-  rspec-core!
-  rspec-expectations!
-  rspec-mocks!
-  rspec-rails!
-  rspec-support!
+  rspec (>= 3.3)
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -23,7 +23,8 @@ RSpec.configure do |config|
     Dir.chdir("spec/dummy") do
       ActiveRecord::Base.connection.disconnect!
       system <<-CMD
-        rake db:drop db:create &&
+        echo &&
+        rake db:environment:set db:drop db:create &&
         git add -A &&
         git reset --hard HEAD 1>/dev/null &&
         rm -rf .git/ 1>/dev/null

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -4,3 +4,10 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+unless Rake::Task.task_defined?('db:environment:set')
+  desc 'dummy task for rails versions where this task does not exist'
+  task 'db:environment:set' do
+    # no-op
+  end
+end


### PR DESCRIPTION
- Some developers were seeing test suite failures under Rails 5 because
  `rake db:environment:set` needed to be run. This task doesn't exist in
  earlier versions of Rails, so we created a dummy task in the dummy app
  so we could call it nonetheless.
- Edge rails appraisal doesn't need edge RSpec.
- Update appraisals.