### PR TITLE
Strip shared leading whitespace from sql_definitions

### DIFF
--- a/lib/fx/statements/function.rb
+++ b/lib/fx/statements/function.rb
@@ -36,6 +36,7 @@ module Fx
             "version or sql_definition must be specified",
           )
         end
+        sql_definition = sql_definition.strip_heredoc if sql_definition
         sql_definition ||= Fx::Definition.new(name: name, version: version).to_sql
 
         Fx.database.create_function(sql_definition)
@@ -93,6 +94,7 @@ module Fx
           )
         end
 
+        sql_definition = sql_definition.strip_heredoc if sql_definition
         sql_definition ||= Fx::Definition.new(
           name: name,
           version: version,

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -39,6 +39,7 @@ module Fx
           version = 1
         end
 
+        sql_definition = sql_definition.strip_heredoc if sql_definition
         sql_definition ||= Fx::Definition.new(
           name: name,
           version: version,
@@ -116,6 +117,7 @@ module Fx
           raise ArgumentError, "on is required"
         end
 
+        sql_definition = sql_definition.strip_heredoc if sql_definition
         sql_definition ||= Fx::Definition.new(
           name: name,
           version: version,


### PR DESCRIPTION
If the whitespace isn't stripped, the whitespace finds its way into the actual function definitions. Successive runs of `schema:load` and `schema:dump` will add 6 spaces of indentation to the function definition (each time). The indentation keeps growing and growing, which results in a lot of churn in schema.rb and unnecessary merge conflicts between disparate source control branches.