### PR TITLE
Make `create_function` reversible with `version`.

### DIFF
--- a/lib/fx/command_recorder/function.rb
+++ b/lib/fx/command_recorder/function.rb
@@ -15,7 +15,7 @@ module Fx
       end
 
       def invert_create_function(args)
-        [:drop_function, args]
+        [:drop_function, [args[0], args[1].try(:except, :version)].compact]
       end
 
       def invert_drop_function(args)

--- a/spec/features/functions/revert_spec.rb
+++ b/spec/features/functions/revert_spec.rb
@@ -21,8 +21,14 @@ describe "Reverting migrations", :db do
         create_function :test
       end
     end
+    migration_with_version = Class.new(migration_class) do
+      def change
+        create_function :test, version: 1
+      end
+    end
 
     expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+    expect { run_migration(migration_with_version, [:up, :down]) }.not_to raise_error
   end
 
   it "can run reversible migrations for dropping functions" do


### PR DESCRIPTION
If you say `create_function("foo", version: 1)` then rolling back the
migration shouldn't fail, even though `drop_function` doesn't have a
`version` keyword argument.

Changes:

- Adds a test to verify that `create_function` is reversible even with a
  `version` parameter.
- Updates the command recorder to exclude `version` when calling
  `drop_function`. (I also considered just giving `drop_function` a new
  noop `version` parameter, which would keep the recorder code simpler,
  but it didn't seem worth polluting the signature of an important
  "public" method.)