### PR TITLE
Support functions with parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 addons:
-  postgresql: "9.4"
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
 before_install:
   - "echo '--colour' > ~/.rspec"
   - "echo 'gem: --no-document' > ~/.gemrc"
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis-ci@example.com"
+env:
+  global:
+    - PGPORT=5433
 branches:
   only:
     - master

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -125,7 +125,11 @@ module Fx
       #
       # @return [void]
       def drop_function(name)
-        execute "DROP FUNCTION #{name}();"
+        if support_drop_function_without_args
+          execute "DROP FUNCTION #{name};"
+        else
+          execute "DROP FUNCTION #{name}();"
+        end
       end
 
       # Drops the trigger from the database
@@ -149,6 +153,13 @@ module Fx
 
       def connection
         Connection.new(connectable.connection)
+      end
+
+      def support_drop_function_without_args
+        # https://www.postgresql.org/docs/9.6/sql-dropfunction.html
+        # https://www.postgresql.org/docs/10/sql-dropfunction.html
+
+        PG.connect.server_version >= 10_00_00
       end
     end
   end

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -48,6 +48,7 @@ describe "User manages functions" do
     successfully "rake db:migrate"
 
     result = execute("SELECT * FROM adder(1, 2) AS result")
+    result["result"] = result["result"].to_i
     expect(result).to eq("result" => 3)
 
     successfully "rails destroy fx:function adder"

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -34,4 +34,23 @@ describe "User manages functions" do
     result = execute("SELECT * FROM test() AS result")
     expect(result).to eq("result" => "testest")
   end
+
+  it "handles functions with arguments" do
+    successfully "rails generate fx:function adder"
+    write_function_definition "adder_v01", <<-EOS
+      CREATE FUNCTION adder(x int, y int)
+      RETURNS int AS $$
+      BEGIN
+          RETURN $1 + $2;
+      END;
+      $$ LANGUAGE plpgsql;
+    EOS
+    successfully "rake db:migrate"
+
+    result = execute("SELECT * FROM adder(1, 2) AS result")
+    expect(result).to eq("result" => 3)
+
+    successfully "rails destroy fx:function adder"
+    successfully "rake db:migrate"
+  end
 end

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -53,22 +53,44 @@ module Fx::Adapters
     end
 
     describe "#drop_function" do
-      it "successfully drops a function" do
-        adapter = Postgres.new
-        adapter.create_function(
-          <<-EOS
-            CREATE OR REPLACE FUNCTION test()
-            RETURNS text AS $$
-            BEGIN
-                RETURN 'test';
-            END;
-            $$ LANGUAGE plpgsql;
-          EOS
-        )
+      context "when the function has arguments" do
+        it "successfully drops a function with the entire function signature" do
+          adapter = Postgres.new
+          adapter.create_function(
+            <<-EOS
+              CREATE FUNCTION adder(x int, y int)
+              RETURNS int AS $$
+              BEGIN
+                  RETURN $1 + $2;
+              END;
+              $$ LANGUAGE plpgsql;
+            EOS
+          )
 
-        adapter.drop_function(:test)
+          adapter.drop_function(:adder)
 
-        expect(adapter.functions.map(&:name)).not_to include("test")
+          expect(adapter.functions.map(&:name)).not_to include("adder")
+        end
+      end
+
+      context "when the function does not have arguments" do
+        it "successfully drops a function" do
+          adapter = Postgres.new
+          adapter.create_function(
+            <<-EOS
+              CREATE OR REPLACE FUNCTION test()
+              RETURNS text AS $$
+              BEGIN
+                  RETURN 'test';
+              END;
+              $$ LANGUAGE plpgsql;
+            EOS
+          )
+
+          adapter.drop_function(:test)
+
+          expect(adapter.functions.map(&:name)).not_to include("test")
+        end
       end
     end
 


### PR DESCRIPTION
copy of #26 just a different sourcebranch

With postgres version above 10 you don't need to send the arguments for dropping function.

In our project we have created functions like car_active, it takes a date as an argument. When we needed to update it we would use the trick https://github.com/teoljungberg/fx/issues/12#issuecomment-390002371.

Since version 10 it is possible to drop functions without passing the arguments so I went ahead and implemented it today. 

I'm not 100% sure know you will take this. I found one of your old Pull request. I dont know why you closed it https://github.com/teoljungberg/fx/pull/8. 

I have seen there has been done some work in the past tring to implemnet both function with arguments and multiple functions same name with different agruments. This solved the first one functions with arguments. Multiple functions same name with different agruments is still unresolved and I  am fine with not haveing it.

This will not improve the experense on versions prior to 10 but for 10 and above it is better. postgres 9.6 will still be active untll 2021 November 11 https://www.postgresql.org/support/versioning/. My feeling are saying that a lot of servers and CI are using an older versions of postgres. ☹️

It says [here](https://docs.travis-ci.com/user/database-setup/#using-a-different-postgresql-version) that TravisCI by default is using 9.2 which is unsopported by postgres. 

Even will these downsides I would like to consider this patch since it is working good for 10 + which was released first on 2017 Oktober 5 and does not ham any thing(execpt complexety).