### PR TITLE
Remove 'public' schema name from the function dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /gemfiles/*.gemfile.lock
+/gemfiles/.bundle/
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -26,7 +26,7 @@ module Fx
       
       # The SQL query used by F(x) to retrieve the function name 
       # with its signature.
-      FUNCTION_NAME_WITH_SIGNATURE = <<-EOS.freeze
+      FUNCTION_NAMES_WITH_THEIR_SIGNATURE = <<-EOS.freeze
           SELECT
               pp.proname AS name,
               CONCAT(pp.proname, '(', pg_get_function_identity_arguments(pp.oid), ')') AS signature
@@ -175,12 +175,12 @@ module Fx
       def support_drop_function_without_args
         # https://www.postgresql.org/docs/9.6/sql-dropfunction.html
         # https://www.postgresql.org/docs/10/sql-dropfunction.html
-        
+
         PG.connect.server_version >= 10_00_00
       end
 
       def function_signature_by_name(name)
-        connection.execute(FUNCTION_NAME_WITH_SIGNATURE).find { |tuple| tuple['name'] == name.to_s }['signature']
+        connection.execute(FUNCTION_NAMES_WITH_THEIR_SIGNATURE).find { |tuple| tuple['name'] == name.to_s }['signature']
       end
     end
   end

--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -21,6 +21,8 @@ module Fx
           ORDER BY pp.oid;
         EOS
 
+        CREATE_FUNCTION_COMMAND = 'CREATE OR REPLACE FUNCTION'
+
         # Wraps #all as a static facade.
         #
         # @return [Array<Fx::Function>]
@@ -48,7 +50,13 @@ module Fx
         end
 
         def to_fx_function(result)
-          Fx::Function.new(result)
+          function = Fx::Function.new(result)
+          remove_public_schema_name_from_definition!(function)
+          function
+        end
+
+        def remove_public_schema_name_from_definition!(function)
+          function.definition.sub! "#{CREATE_FUNCTION_COMMAND} public.", "#{CREATE_FUNCTION_COMMAND} "
         end
       end
     end

--- a/spec/fx/adapters/postgres/functions_spec.rb
+++ b/spec/fx/adapters/postgres/functions_spec.rb
@@ -21,7 +21,7 @@ module Fx
           expect(functions.size).to eq 1
           expect(first.name).to eq "test"
           expect(first.definition).to eq <<-EOS.strip_heredoc
-            CREATE OR REPLACE FUNCTION public.test()
+            CREATE OR REPLACE FUNCTION test()
              RETURNS text
              LANGUAGE plpgsql
             AS $function$


### PR DESCRIPTION
Thank you for this very useful gem! I have made two modifications as listed below:

A] When dumping the functions to the `schema.rb` file, the schema name `public` gets used in the `CREATE FUNCTION` command. For example: `CREATE OR REPLACE FUNCTION public.adder() ....`

When using with the [Apartment gem](https://github.com/influitive/apartment), this is a slight issue. If you are unaware of this Gem, it is a very useful gem used for implementing multi-tenant web apps. The `schema.rb` is run multiple times by this gem, and the contents are created for each of the tenants of the app. For example, if the app has 2 tenants - `client1`, `client2`, there will be three `schema`s in the Postgres database - `public`, `client1` and `client2` all with the same tables and views.

However, because the `public` schema name gets used, the functions get created only in the `public` schema and not in the tenant` schemas. I have fixed this.


B] When I print `PG.connect.server_version`, it prints **90613**. In my version, if there is a function signature `adder(int x, int y)` it does not get dropped by either `DROP FUNCTION adder;` OR `DROP FUNCTION adder();`. Only `DROP FUNCTION adder(int, int)` works. I have fixed this.