### PR TITLE
use the decorated connection to check server version

### DIFF
--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -159,7 +159,7 @@ module Fx
         # https://www.postgresql.org/docs/9.6/sql-dropfunction.html
         # https://www.postgresql.org/docs/10/sql-dropfunction.html
 
-        PG.connect.server_version >= 10_00_00
+        connection.raw_connection.server_version >= 10_00_00
       end
     end
   end

--- a/lib/fx/version.rb
+++ b/lib/fx/version.rb
@@ -1,4 +1,4 @@
 module Fx
   # @api private
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
otherwise fails on cloud providers not using a standard local postgres socket