### PR TITLE
Skip aggregate functions on schema dumping (#34)

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -8,18 +8,37 @@ module Fx
       class Functions
         # The SQL query used by F(x) to retrieve the functions considered
         # dumpable into `db/schema.rb`.
-        FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
+        PG_11_FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-SQL.squish.freeze
           SELECT
-              pp.proname AS name,
-              pg_get_functiondef(pp.oid) AS definition
+            pp.proname,
+            pg_get_functiondef(pp.oid)
           FROM pg_proc pp
           JOIN pg_namespace pn
-              ON pn.oid = pp.pronamespace
+            ON pn.oid = pp.pronamespace
           LEFT JOIN pg_depend pd
-              ON pd.objid = pp.oid AND pd.deptype = 'e'
-          WHERE pn.nspname = 'public' AND pd.objid IS NULL
-          ORDER BY pp.oid;
-        EOS
+            ON pd.objid = pp.oid AND pd.deptype = 'e'
+          WHERE
+            pn.nspname = 'public' AND
+            pd.objid IS NULL AND
+            pp.prokind != 'a'
+          ORDER BY pp.oid
+        SQL
+
+        PG_10_FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-SQL.squish.freeze
+          SELECT
+            pp.proname,
+            pg_get_functiondef(pp.oid)
+          FROM pg_proc pp
+          JOIN pg_namespace pn
+            ON pn.oid = pp.pronamespace
+          LEFT JOIN pg_depend pd
+            ON pd.objid = pp.oid AND pd.deptype = 'e'
+          WHERE
+            pn.nspname = 'public' AND
+            pd.objid IS NULL AND
+            pp.proisagg = 'f'
+          ORDER BY pp.oid
+        SQL
 
         # Wraps #all as a static facade.
         #
@@ -44,7 +63,15 @@ module Fx
         attr_reader :connection
 
         def functions_from_postgres
-          connection.execute(FUNCTIONS_WITH_DEFINITIONS_QUERY)
+          connection.execute(functions_with_definitions_query)
+        end
+
+        def functions_with_definitions_query
+          if connection.raw_connection.server_version >= 11_00_00
+            PG_11_FUNCTIONS_WITH_DEFINITIONS_QUERY
+          else
+            PG_10_FUNCTIONS_WITH_DEFINITIONS_QUERY
+          end
         end
 
         def to_fx_function(result)

--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -12,32 +12,34 @@ module Fx
           SELECT
             pp.proname,
             pg_get_functiondef(pp.oid)
-          FROM pg_proc pp
-          JOIN pg_namespace pn
-            ON pn.oid = pp.pronamespace
-          LEFT JOIN pg_depend pd
-            ON pd.objid = pp.oid AND pd.deptype = 'e'
+          FROM
+            pg_proc pp
+            JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+            LEFT JOIN pg_depend pd ON pd.objid = pp.oid
+              AND pd.deptype = 'e'
           WHERE
-            pn.nspname = 'public' AND
-            pd.objid IS NULL AND
-            pp.prokind != 'a'
-          ORDER BY pp.oid
+            pn.nspname = 'public'
+            AND pd.objid IS NULL
+            AND pp.prokind != 'a'
+          ORDER BY
+            pp.oid
         SQL
 
         PG_10_FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-SQL.squish.freeze
           SELECT
             pp.proname,
             pg_get_functiondef(pp.oid)
-          FROM pg_proc pp
-          JOIN pg_namespace pn
-            ON pn.oid = pp.pronamespace
-          LEFT JOIN pg_depend pd
-            ON pd.objid = pp.oid AND pd.deptype = 'e'
+          FROM
+            pg_proc pp
+            JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+            LEFT JOIN pg_depend pd ON pd.objid = pp.oid
+              AND pd.deptype = 'e'
           WHERE
-            pn.nspname = 'public' AND
-            pd.objid IS NULL AND
-            pp.proisagg = 'f'
-          ORDER BY pp.oid
+            pn.nspname = 'public'
+            AND pd.objid IS NULL
+            AND pp.proisagg = 'f'
+          ORDER BY
+            pp.oid
         SQL
 
         # Wraps #all as a static facade.

--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -10,8 +10,8 @@ module Fx
         # dumpable into `db/schema.rb`.
         PG_11_FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-SQL.squish.freeze
           SELECT
-            pp.proname,
-            pg_get_functiondef(pp.oid)
+            pp.proname AS name,
+            pg_get_functiondef(pp.oid) AS definition
           FROM
             pg_proc pp
             JOIN pg_namespace pn ON pn.oid = pp.pronamespace
@@ -27,8 +27,8 @@ module Fx
 
         PG_10_FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-SQL.squish.freeze
           SELECT
-            pp.proname,
-            pg_get_functiondef(pp.oid)
+            pp.proname AS name,
+            pg_get_functiondef(pp.oid) AS definition
           FROM
             pg_proc pp
             JOIN pg_namespace pn ON pn.oid = pp.pronamespace

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -54,4 +54,22 @@ describe "User manages functions" do
     successfully "rails destroy fx:function adder"
     successfully "rake db:migrate"
   end
+
+  it 'excludes aggregate functions on schema dumping' do
+    connection.execute <<-SQL.strip_heredoc
+      CREATE FUNCTION jsonb_merge(jsonb1 jsonb, jsonb2 jsonb) RETURNS jsonb AS $$
+      SELECT jsonb1 || jsonb2;
+      $$ LANGUAGE SQL;
+    SQL
+
+    connection.execute <<-SQL.strip_heredoc
+      CREATE AGGREGATE jsonb_merge_agg(jsonb)
+      (
+        sfunc = jsonb_merge,
+        stype = jsonb,
+        initcond = '{}'
+      )
+    SQL
+    successfully 'rake db:migrate'
+  end
 end


### PR DESCRIPTION
This should resolve #34 
Postgres can't return definitions for aggregate functions, so we need to exclude them from query. 

In addition the way to do this varies by Postgres version.
Accordingly to PG 11 changelog:

> Replace system catalog pg_proc's proisagg and proiswindow columns with prokind (Peter Eisentraut)
> This new column more clearly distinguishes functions, procedures, aggregates, and window functions.

it's possible by adding condition `pg_proc.prokind != 'a'` for Postgres >= 11 version or `pg_proc.proisagg = 'f'` for other versions.