### PR TITLE
Add config flag to define schema function dumps before other Migration statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis-ci@example.com"
-env:
-  global:
-    - PGPORT=5433
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
-    - gemfile: gemfiles/rails40.gemfile
-    - gemfile: gemfiles/rails41.gemfile
   exclude:
     - rvm: 2.4
       gemfile: gemfiles/rails_edge.gemfile

--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -17,6 +17,7 @@ module Fx
   # ```
   # Fx.configure do |config|
   #   config.database = Fx::Adapters::Postgres
+  #   config.define_functions_at_schema_beginning = true
   # end
   # ```
   def self.configure
@@ -31,8 +32,16 @@ module Fx
     # @return Fx adapter
     attr_accessor :database
 
+    # Configuration flag that prioritizes the order in the schema.rb of triggers and functions before other statements
+    # in order to make directly schema load work when using functions in statements below.
+    #
+    # Defaults false
+    # @return Bool
+    attr_accessor :define_functions_at_schema_beginning
+
     def initialize
       @database = Fx::Adapters::Postgres.new
+      @define_functions_at_schema_beginning = false
     end
   end
 end

--- a/lib/fx/schema_dumper/function.rb
+++ b/lib/fx/schema_dumper/function.rb
@@ -5,8 +5,9 @@ module Fx
     # @api private
     module Function
       def tables(stream)
+        functions(stream) if Fx.configuration.define_functions_at_schema_beginning
         super
-        functions(stream)
+        functions(stream) unless Fx.configuration.define_functions_at_schema_beginning
       end
 
       def functions(stream)


### PR DESCRIPTION
I have made it by using Fx.configuration and with some simple conditionals on the dump code.

We are using our fork in our codebase at the moment and is working fine. It should not affect any previous usage as is using false as default configuration for this flag.

Let me know what you think.