### PR TITLE
Remove 4.0 and 4.1 from the failure matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
-    - gemfile: gemfiles/rails40.gemfile
-    - gemfile: gemfiles/rails41.gemfile
   exclude:
     - rvm: 2.4
       gemfile: gemfiles/rails_edge.gemfile


### PR DESCRIPTION
This PR removes Rails 4.0 and 4.1 from Travis' matrix for allowed
failures, as they have been removed in #31.