### PR TITLE
Add "Contributing" section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ def change
   drop_function :uppercase_users_name, revert_to_version: 2
 end
 ```
+
+## Contributing
+
+See [contributing](CONTRIBUTING.md) for more details.


### PR DESCRIPTION
This PR adds a new "Contributing" section to the `README` which
links to the existing`CONTRIBUTING` file, so that it can be easily
accessible via `README`.