### PR TITLE
Update `rubocop` rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,10 +97,6 @@ Metrics/CyclomaticComplexity:
                  of test cases needed to validate a method.
   Enabled: false
 
-Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
-  Enabled: false
-
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -520,56 +520,6 @@ Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: false
 
-# Performance
-
-Performance/CaseWhenSplat:
-  Description: >-
-                  Place `when` conditions that use splat at the end
-                  of the list of `when` branches.
-  Enabled: false
-
-Performance/Count:
-  Description: >-
-                  Use `count` instead of `select...size`, `reject...size`,
-                  `select...count`, `reject...count`, `select...length`,
-                  and `reject...length`.
-  Enabled: false
-
-Performance/Detect:
-  Description: >-
-                  Use `detect` instead of `select.first`, `find_all.first`,
-                  `select.last`, and `find_all.last`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
-  Enabled: false
-
-Performance/FlatMap:
-  Description: >-
-                  Use `Enumerable#flat_map`
-                  instead of `Enumerable#map...Array#flatten(1)`
-                  or `Enumberable#collect..Array#flatten(1)`
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
-  Enabled: false
-
-Performance/ReverseEach:
-  Description: 'Use `reverse_each` instead of `reverse.each`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
-  Enabled: false
-
-Performance/Size:
-  Description: >-
-                  Use `size` instead of `count` for counting
-                  the number of elements in `Array` and `Hash`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
-  Enabled: false
-
-Performance/StringReplacement:
-  Description: >-
-                  Use `tr` instead of `gsub` when you are replacing the same
-                  number of characters. Use `delete` instead of `gsub` when
-                  you are deleting characters.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
-  Enabled: false
-
 # Rails
 
 Rails/ActionFilter:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -548,7 +548,7 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: false
 
-Performance/Sample:
+Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Fixnum]`.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,12 +140,6 @@ Naming/FileName:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Description: >-
-    Add the frozen_string_literal comment to the top of files
-    to help transition from Ruby 2.3.0 to Ruby 3.0.
-  Enabled: false
-
 Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -321,6 +321,13 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
+Style/Sample:
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: false
+
 Style/SelfAssignment:
   Description: >-
                  Checks for places where self-assignment shorthand should have
@@ -546,13 +553,6 @@ Performance/FlatMap:
 Performance/ReverseEach:
   Description: 'Use `reverse_each` instead of `reverse.each`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
-  Enabled: false
-
-Style/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: false
 
 Performance/Size:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -358,7 +358,7 @@ Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
@@ -367,7 +367,7 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInArrayLiteral:
   Description: 'Checks for trailing comma in array literals.'
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
@@ -376,7 +376,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Description: 'Checks for trailing comma in hash literals.'
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -516,54 +516,6 @@ Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: false
 
-# Rails
-
-Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
-  Enabled: false
-
-Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
-  Enabled: false
-
-Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
-  Enabled: false
-
-Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
-  Enabled: false
-
-Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  Enabled: false
-
-Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
-  Enabled: false
-
-Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  Enabled: false
-
-Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
-  Enabled: false
-
-Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
-  Enabled: false
-
-Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
-  Enabled: false
-
 Style/BlockDelimiters:
   Description: >-
                 Avoid using {...} for multi-line blocks (multiline chaining is

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -467,12 +467,6 @@ Lint/HandleExceptions:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false
 
-Lint/InvalidCharacterLiteral:
-  Description: >-
-                 Checks for invalid character literals with a non-escaped
-                 whitespace character.
-  Enabled: false
-
 Style/InitialIndentation:
   Description: >-
     Checks the indentation of the first non-blank non-comment line in a file.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,10 +106,6 @@ Layout/DotPosition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
   EnforcedStyle: trailing
 
-Layout/EmptyLineAfterMagicComment:
-  Description: 'Checks for a newline after the final magic comment.'
-  Enabled: false
-
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
@@ -117,6 +113,10 @@ Style/DoubleNegation:
 
 Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Description: 'Checks for a newline after the final magic comment.'
   Enabled: false
 
 Style/EmptyLiteral:
@@ -138,12 +138,6 @@ Style/EvenOdd:
 Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
-
-Naming/MemoizedInstanceVariableName:
-  Description: >-
-                  This cop checks for memoized methods whose instance variable
-                  name does not match the method name.
-  EnforcedStyleForLeadingUnderscores: required
 
 Naming/FileName:
   Description: 'Use snake_case for source file names.'
@@ -207,6 +201,12 @@ Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Max: 80
+
+Naming/MemoizedInstanceVariableName:
+  Description: >-
+                  This cop checks for memoized methods whose instance variable
+                  name does not match the method name.
+  EnforcedStyleForLeadingUnderscores: required
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,6 +139,12 @@ Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
 
+Naming/MemoizedInstanceVariableName:
+  Description: >-
+                  This cop checks for memoized methods whose instance variable
+                  name does not match the method name.
+  EnforcedStyleForLeadingUnderscores: required
+
 Naming/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -150,7 +150,7 @@ Naming/FileName:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: false
 
-Lint/FlipFlop:
+Style/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -509,13 +509,6 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: false
 
-Lint/UnneededDisable:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
-  Enabled: false
-
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -364,9 +364,17 @@ Style/TrailingCommaInArguments:
     - no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  EnforcedStyleForMultiline: comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   EnforcedStyleForMultiline: comma
   SupportedStyles:
     - comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
     - "spec/dummy/**/*"
     - "tmp/**/*"
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
@@ -22,7 +22,7 @@ Style/AsciiComments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: false
 
-Style/AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: false
@@ -105,7 +105,7 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
   EnforcedStyle: trailing
@@ -135,11 +135,11 @@ Style/EvenOdd:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: false
 
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
 
-Style/FileName:
+Naming/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: false
@@ -150,7 +150,7 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false
@@ -218,7 +218,7 @@ Style/ModuleFunction:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: false
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Description: >-
                  Checks indentation of binary operations that span more than
                  one line.
@@ -230,7 +230,7 @@ Style/MultilineBlockChain:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Description: >-
                  Checks indentation of method calls with the dot operator
                  that span more than one line.
@@ -278,7 +278,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: false
@@ -298,7 +298,7 @@ Style/PerlBackrefs:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
   Enabled: false
 
-Style/PredicateName:
+Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
   NamePrefixBlacklist:
@@ -435,7 +435,7 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: false
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -467,7 +467,7 @@ Lint/HandleExceptions:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false
 
-Style/InitialIndentation:
+Layout/InitialIndentation:
   Description: >-
     Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -472,10 +472,6 @@ Style/InitialIndentation:
     Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: false
 
-Lint/LiteralInCondition:
-  Description: 'Checks of literals used in conditions.'
-  Enabled: false
-
 Lint/LiteralInInterpolation:
   Description: 'Checks for literals used in interpolation.'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -327,7 +327,7 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
-Style/Sample:
+Performance/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Fixnum]`.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,10 @@ Layout/DotPosition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
   EnforcedStyle: trailing
 
+Layout/EmptyLineAfterMagicComment:
+  Description: 'Checks for a newline after the final magic comment.'
+  Enabled: false
+
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,6 +135,12 @@ Style/EvenOdd:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: false
 
+Style/ExpandPathArguments:
+  Description: >-
+                  This cop checks for use of the `File.expand_path` arguments.
+                  Likewise, it also checks for the `Pathname.new` argument.
+  Enabled: false
+
 Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true

--- a/Appraisals
+++ b/Appraisals
@@ -22,6 +22,6 @@ if RUBY_VERSION > "2.2.0"
 
   appraise "rails-edge" do
     gem "rails", github: "rails/rails"
-    gem "arel", :github => "rails/arel"
+    gem "arel", github: "rails/arel"
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in fx.gemspec
 gemspec

--- a/bin/appraisal
+++ b/bin/appraisal
@@ -8,9 +8,10 @@
 #
 
 require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
-
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(
+  "../../Gemfile",
+  Pathname.new(__FILE__).realpath,
+)
 require "rubygems"
 require "bundler/setup"
 

--- a/bin/rake
+++ b/bin/rake
@@ -8,8 +8,10 @@
 #
 
 require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(
+  "../../Gemfile",
+  Pathname.new(__FILE__).realpath,
+)
 
 require "rubygems"
 require "bundler/setup"

--- a/bin/rspec
+++ b/bin/rspec
@@ -8,8 +8,10 @@
 #
 
 require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(
+  "../../Gemfile",
+  Pathname.new(__FILE__).realpath,
+)
 
 require "rubygems"
 require "bundler/setup"

--- a/bin/yard
+++ b/bin/yard
@@ -8,8 +8,10 @@
 #
 
 require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(
+  "../../Gemfile",
+  Pathname.new(__FILE__).realpath,
+)
 
 require "rubygems"
 require "bundler/setup"

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |spec|
   spec.summary       = <<-SUMMARY
     Support for database functions and triggers in Rails migrations
   SUMMARY
+  spec.homepage      = "https://github.com/teoljungberg/fx"
   spec.description   = <<-DESCRIPTION
     Adds methods to ActiveRecord::Migration to create and manage database functions
     and triggers in Rails
   DESCRIPTION
-  spec.homepage      = "https://github.com/teoljungberg/fx"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -8,7 +8,9 @@ Gem::Specification.new do |spec|
   spec.version       = Fx::VERSION
   spec.authors       = ["Teo Ljungberg"]
   spec.email         = ["teo@teoljungberg.com"]
-  spec.summary       = %q{Support for database functions and triggers in Rails migrations}
+  spec.summary       = <<-SUMMARY
+    Support for database functions and triggers in Rails migrations
+  SUMMARY
   spec.description   = <<-DESCRIPTION
     Adds methods to ActiveRecord::Migration to create and manage database functions
     and triggers in Rails

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -22,16 +22,16 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "ammeter", ">= 1.1.3"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "database_cleaner"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 3.3"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "ammeter", ">= 1.1.3"
-  spec.add_development_dependency "yard"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "redcarpet"
+  spec.add_development_dependency "rspec", ">= 3.3"
+  spec.add_development_dependency "yard"
 
   spec.add_dependency "activerecord", ">= 4.0.0"
   spec.add_dependency "railties", ">= 4.0.0"

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "fx/version"
 
@@ -16,25 +16,25 @@ Gem::Specification.new do |spec|
     and triggers in Rails
   DESCRIPTION
   spec.homepage      = "https://github.com/teoljungberg/fx"
-  spec.license       = 'MIT'
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^spec/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
   spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "bundler", '>= 1.5'
+  spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", '>= 3.3'
+  spec.add_development_dependency "rspec", ">= 3.3"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "ammeter", '>= 1.1.3'
+  spec.add_development_dependency "ammeter", ">= 1.1.3"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "redcarpet"
 
-  spec.add_dependency "activerecord", '>= 4.0.0'
-  spec.add_dependency "railties", '>= 4.0.0'
+  spec.add_dependency "activerecord", ">= 4.0.0"
+  spec.add_dependency "railties", ">= 4.0.0"
 
   spec.required_ruby_version = "~> 2.1"
 end

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
-gem "railties", "~> 4.2.0"
 gem "pg", "~> 0.15"
+gem "railties", "~> 4.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", github: "rails/rails"
 gem "arel", github: "rails/arel"
+gem "rails", github: "rails/rails"
 
 gemspec path: "../"

--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -8,7 +8,7 @@ module Fx
       class Functions
         # The SQL query used by F(x) to retrieve the functions considered
         # dumpable into `db/schema.rb`.
-        FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
+        FUNCTIONS_WITH_DEFINITIONS_QUERY = <<-SQL.freeze
           SELECT
               pp.proname AS name,
               pg_get_functiondef(pp.oid) AS definition
@@ -19,7 +19,7 @@ module Fx
               ON pd.objid = pp.oid AND pd.deptype = 'e'
           WHERE pn.nspname = 'public' AND pd.objid IS NULL
           ORDER BY pp.oid;
-        EOS
+        SQL
 
         # Wraps #all as a static facade.
         #

--- a/lib/fx/adapters/postgres/triggers.rb
+++ b/lib/fx/adapters/postgres/triggers.rb
@@ -8,7 +8,7 @@ module Fx
       class Triggers
         # The SQL query used by F(x) to retrieve the triggers considered
         # dumpable into `db/schema.rb`.
-        TRIGGERS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
+        TRIGGERS_WITH_DEFINITIONS_QUERY = <<-SQL.freeze
           SELECT
               pt.tgname AS name,
               pg_get_triggerdef(pt.oid) AS definition
@@ -20,7 +20,7 @@ module Fx
           WHERE pt.tgname
           NOT ILIKE '%constraint%' AND pt.tgname NOT ILIKE 'pg%'
           ORDER BY pc.oid;
-        EOS
+        SQL
 
         # Wraps #all as a static facade.
         #

--- a/lib/fx/command_recorder.rb
+++ b/lib/fx/command_recorder.rb
@@ -14,7 +14,9 @@ module Fx
       arguments = Arguments.new(args)
 
       if arguments.revert_to_version.nil?
-        message = "`#{method}` is reversible only if given a `revert_to_version`"
+        message = <<~MESSAGE
+          `#{method}` is reversible only if given a `revert_to_version`
+        MESSAGE
         raise ActiveRecord::IrreversibleMigration, message
       end
 

--- a/lib/fx/command_recorder/arguments.rb
+++ b/lib/fx/command_recorder/arguments.rb
@@ -29,7 +29,7 @@ module Fx
       private
 
       def options
-        @options ||= @args[1] || {}
+        @_options ||= @args[1] || {}
       end
 
       def options_for_revert

--- a/lib/fx/definition.rb
+++ b/lib/fx/definition.rb
@@ -34,9 +34,9 @@ module Fx
     end
 
     def find_file
-      migration_paths.lazy
-        .map { |migration_path| File.expand_path(File.join("..", "..", path), migration_path) }
-        .find { |definition_path| File.exist?(definition_path) }
+      migration_paths.lazy.map do |migration_path|
+        File.expand_path(File.join("..", "..", path), migration_path)
+      end.find { |definition_path| File.exist?(definition_path) }
     end
 
     def migration_paths

--- a/lib/fx/definition.rb
+++ b/lib/fx/definition.rb
@@ -36,7 +36,7 @@ module Fx
     def find_file
       migration_paths.lazy.map do |migration_path|
         File.expand_path(File.join("..", "..", path), migration_path)
-      end.find { |definition_path| File.exist?(definition_path) }
+      end.detect { |definition_path| File.exist?(definition_path) }
     end
 
     def migration_paths

--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -16,10 +16,10 @@ module Fx
     end
 
     def to_schema
-      <<-SCHEMA.indent(2)
-create_function :#{name}, sql_definition: <<-\SQL
-#{definition.indent(4).rstrip}
-SQL
+      <<~SCHEMA.indent(2)
+          create_function :#{name}, sql_definition: <<-\SQL
+          #{definition.indent(4).rstrip}
+        SQL
       SCHEMA
     end
   end

--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -17,8 +17,8 @@ module Fx
 
     def to_schema
       <<~SCHEMA.indent(2)
-          create_function :#{name}, sql_definition: <<-\SQL
-          #{definition.indent(4).rstrip}
+        create_function :#{name}, sql_definition: <<-\SQL
+        #{definition.indent(4).rstrip}
         SQL
       SCHEMA
     end

--- a/lib/fx/statements/function.rb
+++ b/lib/fx/statements/function.rb
@@ -37,7 +37,10 @@ module Fx
           )
         end
         sql_definition = sql_definition.strip_heredoc if sql_definition
-        sql_definition ||= Fx::Definition.new(name: name, version: version).to_sql
+        sql_definition ||= Fx::Definition.new(
+          name: name,
+          version: version,
+        ).to_sql
 
         Fx.database.create_function(sql_definition)
       end
@@ -86,7 +89,12 @@ module Fx
       #     $$ LANGUAGE plpgsql;
       #   SQL
       #
-      def update_function(name, version: nil, sql_definition: nil, revert_to_version: nil)
+      def update_function(
+        name,
+        version: nil,
+        sql_definition: nil,
+        revert_to_version: nil
+      )
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,

--- a/lib/fx/statements/function.rb
+++ b/lib/fx/statements/function.rb
@@ -56,7 +56,7 @@ module Fx
       # @example Drop a function, rolling back to version 2 on rollback
       #   drop_function(:uppercase_users_name, revert_to_version: 2)
       #
-      def drop_function(name, revert_to_version: nil)
+      def drop_function(name, _revert_to_version: nil)
         Fx.database.drop_function(name)
       end
 
@@ -93,7 +93,7 @@ module Fx
         name,
         version: nil,
         sql_definition: nil,
-        revert_to_version: nil
+        _revert_to_version: nil
       )
         if version.nil? && sql_definition.nil?
           raise(

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -98,7 +98,13 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      def update_trigger(name, version: nil, on: nil, sql_definition: nil, revert_to_version: nil)
+      def update_trigger(
+        name,
+        version: nil,
+        on: nil,
+        sql_definition: nil,
+        revert_to_version: nil
+      )
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -27,7 +27,7 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      def create_trigger(name, version: nil, on: nil, sql_definition: nil)
+      def create_trigger(name, version: nil, _on: nil, sql_definition: nil)
         if version.present? && sql_definition.present?
           raise(
             ArgumentError,
@@ -62,7 +62,7 @@ module Fx
       # @example Drop a trigger, rolling back to version 3 on rollback
       #   drop_trigger(:log_inserts, on: :users, revert_to_version: 3)
       #
-      def drop_trigger(name, on:, revert_to_version: nil)
+      def drop_trigger(name, on:, _revert_to_version: nil)
         Fx.database.drop_trigger(name, on: on)
       end
 
@@ -103,7 +103,7 @@ module Fx
         version: nil,
         on: nil,
         sql_definition: nil,
-        revert_to_version: nil
+        _revert_to_version: nil
       )
         if version.nil? && sql_definition.nil?
           raise(

--- a/lib/fx/version.rb
+++ b/lib/fx/version.rb
@@ -1,4 +1,4 @@
 module Fx
   # @api private
-  VERSION = "0.5.0"
+  VERSION = "0.5.0".freeze
 end

--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -87,11 +87,11 @@ module Fx
       end
 
       def updating_existing_function?
-        previous_version > 0
+        previous_version.positive?
       end
 
       def creating_new_function?
-        previous_version == 0
+        previous_version.zero?
       end
 
       def definition

--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -79,7 +79,7 @@ module Fx
       private
 
       def function_definition_path
-        @_function_definition_path ||= Rails.root.join(*%w(db functions))
+        @_function_definition_path ||= Rails.root.join("db", "functions")
       end
 
       def version_regex

--- a/lib/generators/fx/trigger/trigger_generator.rb
+++ b/lib/generators/fx/trigger/trigger_generator.rb
@@ -23,12 +23,12 @@ module Fx
         if updating_existing_trigger?
           migration_template(
             "db/migrate/update_trigger.erb",
-            "db/migrate/update_trigger_#{file_name}_to_version_#{version}.rb"
+            "db/migrate/update_trigger_#{file_name}_to_version_#{version}.rb",
           )
         else
           migration_template(
             "db/migrate/create_trigger.erb",
-            "db/migrate/create_trigger_#{file_name}.rb"
+            "db/migrate/create_trigger_#{file_name}.rb",
           )
         end
       end

--- a/lib/generators/fx/trigger/trigger_generator.rb
+++ b/lib/generators/fx/trigger/trigger_generator.rb
@@ -109,7 +109,7 @@ module Fx
       end
 
       def trigger_definition_path
-        @_trigger_definition_path ||= Rails.root.join(*["db", "triggers"])
+        @_trigger_definition_path ||= Rails.root.join("db", "triggers")
       end
     end
   end

--- a/lib/generators/fx/trigger/trigger_generator.rb
+++ b/lib/generators/fx/trigger/trigger_generator.rb
@@ -97,7 +97,7 @@ module Fx
       end
 
       def updating_existing_trigger?
-        previous_version > 0
+        previous_version.positive?
       end
 
       def definition

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -3,14 +3,14 @@ require "acceptance_helper"
 describe "User manages functions" do
   it "handles simple functions" do
     successfully "rails generate fx:function test"
-    write_function_definition "test_v01", <<-EOS
+    write_function_definition "test_v01", <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
           RETURN 'test';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     successfully "rake db:migrate"
 
     result = execute("SELECT * FROM test() AS result")
@@ -21,14 +21,14 @@ describe "User manages functions" do
       "db/functions/test_v01.sql",
       "db/functions/test_v02.sql",
     )
-    write_function_definition "test_v02", <<-EOS
+    write_function_definition "test_v02", <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
           RETURN 'testest';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     successfully "rake db:migrate"
 
     result = execute("SELECT * FROM test() AS result")
@@ -37,14 +37,14 @@ describe "User manages functions" do
 
   it "handles functions with arguments" do
     successfully "rails generate fx:function adder"
-    write_function_definition "adder_v01", <<-EOS
+    write_function_definition "adder_v01", <<-SQL
       CREATE FUNCTION adder(x int, y int)
       RETURNS int AS $$
       BEGIN
           RETURN $1 + $2;
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     successfully "rake db:migrate"
 
     result = execute("SELECT * FROM adder(1, 2) AS result")

--- a/spec/acceptance/user_manages_triggers_spec.rb
+++ b/spec/acceptance/user_manages_triggers_spec.rb
@@ -13,7 +13,9 @@ describe "User manages triggers" do
       END;
       $$ LANGUAGE plpgsql;
     SQL
-    successfully "rails generate fx:trigger uppercase_users_name table_name:users"
+    successfully(
+      "rails generate fx:trigger uppercase_users_name table_name:users",
+    )
     write_trigger_definition "uppercase_users_name_v01", <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
@@ -31,7 +33,9 @@ describe "User manages triggers" do
     result = execute("SELECT upper_name FROM users WHERE name = 'Bob';")
     expect(result).to eq("upper_name" => "BOB")
 
-    successfully "rails generate fx:trigger uppercase_users_name table_name:users"
+    successfully(
+      "rails generate fx:trigger uppercase_users_name table_name:users",
+    )
     write_trigger_definition "uppercase_users_name_v02", <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users

--- a/spec/acceptance/user_manages_triggers_spec.rb
+++ b/spec/acceptance/user_manages_triggers_spec.rb
@@ -4,7 +4,7 @@ describe "User manages triggers" do
   it "handles simple triggers" do
     successfully "rails generate model user name:string upper_name:string"
     successfully "rails generate fx:function uppercase_users_name"
-    write_function_definition "uppercase_users_name_v01", <<-EOS
+    write_function_definition "uppercase_users_name_v01", <<-SQL
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -12,38 +12,38 @@ describe "User manages triggers" do
         RETURN NEW;
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     successfully "rails generate fx:trigger uppercase_users_name table_name:users"
-    write_trigger_definition "uppercase_users_name_v01", <<-EOS
+    write_trigger_definition "uppercase_users_name_v01", <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
-    EOS
+    SQL
     successfully "rake db:migrate"
 
-    execute <<-EOS
+    execute <<-SQL
       INSERT INTO users
       (name, created_at, updated_at)
       VALUES
       ('Bob', NOW(), NOW());
-    EOS
+    SQL
     result = execute("SELECT upper_name FROM users WHERE name = 'Bob';")
     expect(result).to eq("upper_name" => "BOB")
 
     successfully "rails generate fx:trigger uppercase_users_name table_name:users"
-    write_trigger_definition "uppercase_users_name_v02", <<-EOS
+    write_trigger_definition "uppercase_users_name_v02", <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
-    EOS
+    SQL
     successfully "rake db:migrate"
-    execute <<-EOS
+    execute <<-SQL
       UPDATE users
       SET name = 'Alice'
       WHERE id = 1;
-    EOS
+    SQL
 
     result = execute("SELECT upper_name FROM users WHERE name = 'Alice';")
     expect(result).to eq("upper_name" => "ALICE")

--- a/spec/features/functions/migrations_spec.rb
+++ b/spec/features/functions/migrations_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe "Function migrations", :db do
   around do |example|
-    sql_definition = <<-EOS
+    sql_definition = <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
           RETURN 'test';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     with_function_definition(name: :test, sql_definition: sql_definition) do
       example.run
     end
@@ -40,14 +40,14 @@ describe "Function migrations", :db do
   it "can run migrations that updates functions" do
     connection.create_function(:test)
 
-    sql_definition = <<-EOS
+    sql_definition = <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
           RETURN 'testest';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     with_function_definition(
       name: :test,
       version: 2,

--- a/spec/features/functions/revert_spec.rb
+++ b/spec/features/functions/revert_spec.rb
@@ -22,7 +22,7 @@ describe "Reverting migrations", :db do
       end
     end
 
-    expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+    expect { run_migration(migration, %i[up down]) }.not_to raise_error
   end
 
   it "can run reversible migrations for dropping functions" do
@@ -39,8 +39,8 @@ describe "Reverting migrations", :db do
       end
     end
 
-    expect { run_migration(good_migration, [:up, :down]) }.not_to raise_error
-    expect { run_migration(bad_migration, [:up, :down]) }.
+    expect { run_migration(good_migration, %i[up down]) }.not_to raise_error
+    expect { run_migration(bad_migration, %i[up down]) }.
       to raise_error(
         ActiveRecord::IrreversibleMigration,
         /`create_function` is reversible only if given a `revert_to_version`/,
@@ -69,7 +69,7 @@ describe "Reverting migrations", :db do
         end
       end
 
-      expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+      expect { run_migration(migration, %i[up down]) }.not_to raise_error
     end
   end
 end

--- a/spec/features/functions/revert_spec.rb
+++ b/spec/features/functions/revert_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe "Reverting migrations", :db do
   around do |example|
-    sql_definition = <<-EOS
+    sql_definition = <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
           RETURN 'test';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     with_function_definition(name: :test, sql_definition: sql_definition) do
       example.run
     end
@@ -50,14 +50,14 @@ describe "Reverting migrations", :db do
   it "can run reversible migrations for updating functions" do
     connection.create_function(:test)
 
-    sql_definition = <<-EOS
+    sql_definition = <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
         RETURN 'bar';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     with_function_definition(
       name: :test,
       version: 2,

--- a/spec/features/triggers/migrations_spec.rb
+++ b/spec/features/triggers/migrations_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe "Trigger migrations", :db do
   around do |example|
-    connection.execute <<-EOS
+    connection.execute <<-SQL
       CREATE TABLE users (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
       );
-    EOS
-    Fx.database.create_function <<-EOS
+    SQL
+    Fx.database.create_function <<-SQL
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -17,13 +17,13 @@ describe "Trigger migrations", :db do
         RETURN NEW;
       END;
       $$ LANGUAGE plpgsql;
-    EOS
-    sql_definition = <<-EOS
+    SQL
+    sql_definition = <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
-    EOS
+    SQL
     with_trigger_definition(
       name: :uppercase_users_name,
       sql_definition: sql_definition,

--- a/spec/features/triggers/revert_spec.rb
+++ b/spec/features/triggers/revert_spec.rb
@@ -39,7 +39,7 @@ describe "Reverting migrations", :db do
       end
     end
 
-    expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+    expect { run_migration(migration, %i[up down]) }.not_to raise_error
   end
 
   it "can run reversible migrations for dropping triggers" do
@@ -56,8 +56,8 @@ describe "Reverting migrations", :db do
       end
     end
 
-    expect { run_migration(good_migration, [:up, :down]) }.not_to raise_error
-    expect { run_migration(bad_migration, [:up, :down]) }.
+    expect { run_migration(good_migration, %i[up down]) }.not_to raise_error
+    expect { run_migration(bad_migration, %i[up down]) }.
       to raise_error(
         ActiveRecord::IrreversibleMigration,
         /`create_trigger` is reversible only if given a `revert_to_version`/,
@@ -89,7 +89,7 @@ describe "Reverting migrations", :db do
         end
       end
 
-      expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+      expect { run_migration(migration, %i[up down]) }.not_to raise_error
     end
   end
 end

--- a/spec/features/triggers/revert_spec.rb
+++ b/spec/features/triggers/revert_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe "Reverting migrations", :db do
   around do |example|
-    connection.execute <<-EOS
+    connection.execute <<-SQL
       CREATE TABLE users (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
       );
-    EOS
-    Fx.database.create_function <<-EOS
+    SQL
+    Fx.database.create_function <<-SQL
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -17,13 +17,13 @@ describe "Reverting migrations", :db do
         RETURN NEW;
       END;
       $$ LANGUAGE plpgsql;
-    EOS
-    sql_definition = <<-EOS
+    SQL
+    sql_definition = <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
-    EOS
+    SQL
     with_trigger_definition(
       name: :uppercase_users_name,
       sql_definition: sql_definition,
@@ -67,12 +67,12 @@ describe "Reverting migrations", :db do
   it "can run reversible migrations for updating triggers" do
     connection.create_trigger(:uppercase_users_name)
 
-    sql_definition = <<-EOS
+    sql_definition = <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
-    EOS
+    SQL
     with_trigger_definition(
       name: :uppercase_users_name,
       sql_definition: sql_definition,

--- a/spec/fx/adapters/postgres/functions_spec.rb
+++ b/spec/fx/adapters/postgres/functions_spec.rb
@@ -6,21 +6,21 @@ module Fx
       describe ".all" do
         it "returns `Function` objects" do
           connection = ActiveRecord::Base.connection
-          connection.execute <<-EOS.strip_heredoc
+          connection.execute <<-SQL.strip_heredoc
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
                 RETURN 'test';
             END;
             $$ LANGUAGE plpgsql;
-          EOS
+          SQL
 
           functions = Postgres::Functions.new(connection).all
 
           first = functions.first
           expect(functions.size).to eq 1
           expect(first.name).to eq "test"
-          expect(first.definition).to eq <<-EOS.strip_heredoc
+          expect(first.definition).to eq <<-SQL.strip_heredoc
             CREATE OR REPLACE FUNCTION public.test()
              RETURNS text
              LANGUAGE plpgsql
@@ -29,7 +29,7 @@ module Fx
                 RETURN 'test';
             END;
             $function$
-          EOS
+          SQL
         end
       end
     end

--- a/spec/fx/adapters/postgres/triggers_spec.rb
+++ b/spec/fx/adapters/postgres/triggers_spec.rb
@@ -37,7 +37,9 @@ module Fx
           expect(first.definition).to include("BEFORE INSERT")
           expect(first.definition).to match(/ON [public\.users|users]/)
           expect(first.definition).to include("FOR EACH ROW")
-          expect(first.definition).to include("EXECUTE PROCEDURE uppercase_users_name()")
+          expect(first.definition).to include(
+            "EXECUTE PROCEDURE uppercase_users_name()",
+          )
         end
       end
     end

--- a/spec/fx/adapters/postgres/triggers_spec.rb
+++ b/spec/fx/adapters/postgres/triggers_spec.rb
@@ -6,14 +6,14 @@ module Fx
       describe ".all" do
         it "returns `Trigger` objects" do
           connection = ActiveRecord::Base.connection
-          connection.execute <<-EOS.strip_heredoc
+          connection.execute <<-SQL.strip_heredoc
             CREATE TABLE users (
                 id int PRIMARY KEY,
                 name varchar(256),
                 upper_name varchar(256)
             );
-          EOS
-          connection.execute <<-EOS.strip_heredoc
+          SQL
+          connection.execute <<-SQL.strip_heredoc
             CREATE OR REPLACE FUNCTION uppercase_users_name()
             RETURNS trigger AS $$
             BEGIN
@@ -21,13 +21,13 @@ module Fx
               RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
-          EOS
-          connection.execute <<-EOS.strip_heredoc
+          SQL
+          connection.execute <<-SQL.strip_heredoc
             CREATE TRIGGER uppercase_users_name
                 BEFORE INSERT ON users
                 FOR EACH ROW
                 EXECUTE PROCEDURE uppercase_users_name();
-          EOS
+          SQL
 
           triggers = Postgres::Triggers.new(connection).all
 

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -6,14 +6,14 @@ module Fx::Adapters
       it "successfully creates a function" do
         adapter = Postgres.new
         adapter.create_function(
-          <<-EOS
+          <<-SQL
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
                 RETURN 'test';
             END;
             $$ LANGUAGE plpgsql;
-          EOS
+          SQL
         )
 
         expect(adapter.functions.map(&:name)).to include("test")
@@ -22,15 +22,15 @@ module Fx::Adapters
 
     describe "#create_trigger" do
       it "successfully creates a trigger" do
-        connection.execute <<-EOS
+        connection.execute <<-SQL
           CREATE TABLE users (
               id int PRIMARY KEY,
               name varchar(256),
               upper_name varchar(256)
           );
-        EOS
+        SQL
         adapter = Postgres.new
-        adapter.create_function <<-EOS
+        adapter.create_function <<-SQL
           CREATE OR REPLACE FUNCTION uppercase_users_name()
           RETURNS trigger AS $$
           BEGIN
@@ -38,14 +38,14 @@ module Fx::Adapters
             RETURN NEW;
           END;
           $$ LANGUAGE plpgsql;
-        EOS
+        SQL
         adapter.create_trigger(
-          <<-EOS
+          <<-SQL
             CREATE TRIGGER uppercase_users_name
                 BEFORE INSERT ON users
                 FOR EACH ROW
                 EXECUTE PROCEDURE uppercase_users_name();
-          EOS
+          SQL
         )
 
         expect(adapter.triggers.map(&:name)).to include("uppercase_users_name")
@@ -57,14 +57,14 @@ module Fx::Adapters
         it "successfully drops a function with the entire function signature" do
           adapter = Postgres.new
           adapter.create_function(
-            <<-EOS
+            <<-SQL
               CREATE FUNCTION adder(x int, y int)
               RETURNS int AS $$
               BEGIN
                   RETURN $1 + $2;
               END;
               $$ LANGUAGE plpgsql;
-            EOS
+            SQL
           )
 
           adapter.drop_function(:adder)
@@ -77,14 +77,14 @@ module Fx::Adapters
         it "successfully drops a function" do
           adapter = Postgres.new
           adapter.create_function(
-            <<-EOS
+            <<-SQL
               CREATE OR REPLACE FUNCTION test()
               RETURNS text AS $$
               BEGIN
                   RETURN 'test';
               END;
               $$ LANGUAGE plpgsql;
-            EOS
+            SQL
           )
 
           adapter.drop_function(:test)
@@ -98,14 +98,14 @@ module Fx::Adapters
       it "finds functions and builds Fx::Function objects" do
         adapter = Postgres.new
         adapter.create_function(
-          <<-EOS
+          <<-SQL
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
                 RETURN 'test';
             END;
             $$ LANGUAGE plpgsql;
-          EOS
+          SQL
         )
 
         expect(adapter.functions.map(&:name)).to eq ["test"]
@@ -114,15 +114,15 @@ module Fx::Adapters
 
     describe "#triggers" do
       it "finds triggers and builds Fx::Trigger objects" do
-        connection.execute <<-EOS
+        connection.execute <<-SQL
           CREATE TABLE users (
               id int PRIMARY KEY,
               name varchar(256),
               upper_name varchar(256)
           );
-        EOS
+        SQL
         adapter = Postgres.new
-        adapter.create_function <<-EOS
+        adapter.create_function <<-SQL
           CREATE OR REPLACE FUNCTION uppercase_users_name()
           RETURNS trigger AS $$
           BEGIN
@@ -130,13 +130,13 @@ module Fx::Adapters
             RETURN NEW;
           END;
           $$ LANGUAGE plpgsql;
-        EOS
-        sql_definition = <<-EOS
+        SQL
+        sql_definition = <<-SQL
           CREATE TRIGGER uppercase_users_name
               BEFORE INSERT ON users
               FOR EACH ROW
               EXECUTE PROCEDURE uppercase_users_name()
-        EOS
+        SQL
         adapter.create_trigger(sql_definition)
 
         expect(adapter.triggers.map(&:name)).to eq ["uppercase_users_name"]

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -1,80 +1,10 @@
 require "spec_helper"
 
-module Fx::Adapters
-  describe Postgres, :db do
-    describe "#create_function" do
-      it "successfully creates a function" do
-        adapter = Postgres.new
-        adapter.create_function(
-          <<-SQL,
-            CREATE OR REPLACE FUNCTION test()
-            RETURNS text AS $$
-            BEGIN
-                RETURN 'test';
-            END;
-            $$ LANGUAGE plpgsql;
-          SQL
-        )
-
-        expect(adapter.functions.map(&:name)).to include("test")
-      end
-    end
-
-    describe "#create_trigger" do
-      it "successfully creates a trigger" do
-        connection.execute <<-SQL
-          CREATE TABLE users (
-              id int PRIMARY KEY,
-              name varchar(256),
-              upper_name varchar(256)
-          );
-        SQL
-        adapter = Postgres.new
-        adapter.create_function <<-SQL
-          CREATE OR REPLACE FUNCTION uppercase_users_name()
-          RETURNS trigger AS $$
-          BEGIN
-            NEW.upper_name = UPPER(NEW.name);
-            RETURN NEW;
-          END;
-          $$ LANGUAGE plpgsql;
-        SQL
-        adapter.create_trigger(
-          <<-SQL,
-            CREATE TRIGGER uppercase_users_name
-                BEFORE INSERT ON users
-                FOR EACH ROW
-                EXECUTE PROCEDURE uppercase_users_name();
-          SQL
-        )
-
-        expect(adapter.triggers.map(&:name)).to include("uppercase_users_name")
-      end
-    end
-
-    describe "#drop_function" do
-      context "when the function has arguments" do
-        it "successfully drops a function with the entire function signature" do
-          adapter = Postgres.new
-          adapter.create_function(
-            <<-SQL,
-              CREATE FUNCTION adder(x int, y int)
-              RETURNS int AS $$
-              BEGIN
-                  RETURN $1 + $2;
-              END;
-              $$ LANGUAGE plpgsql;
-            SQL
-          )
-
-          adapter.drop_function(:adder)
-
-          expect(adapter.functions.map(&:name)).not_to include("adder")
-        end
-      end
-
-      context "when the function does not have arguments" do
-        it "successfully drops a function" do
+module Fx
+  module Adapters
+    describe Postgres, :db do
+      describe "#create_function" do
+        it "successfully creates a function" do
           adapter = Postgres.new
           adapter.create_function(
             <<-SQL,
@@ -87,59 +17,131 @@ module Fx::Adapters
             SQL
           )
 
-          adapter.drop_function(:test)
-
-          expect(adapter.functions.map(&:name)).not_to include("test")
+          expect(adapter.functions.map(&:name)).to include("test")
         end
       end
-    end
 
-    describe "#functions" do
-      it "finds functions and builds Fx::Function objects" do
-        adapter = Postgres.new
-        adapter.create_function(
-          <<-SQL,
-            CREATE OR REPLACE FUNCTION test()
-            RETURNS text AS $$
+      describe "#create_trigger" do
+        it "successfully creates a trigger" do
+          connection.execute <<-SQL
+            CREATE TABLE users (
+                id int PRIMARY KEY,
+                name varchar(256),
+                upper_name varchar(256)
+            );
+          SQL
+          adapter = Postgres.new
+          adapter.create_function <<-SQL
+            CREATE OR REPLACE FUNCTION uppercase_users_name()
+            RETURNS trigger AS $$
             BEGIN
-                RETURN 'test';
+              NEW.upper_name = UPPER(NEW.name);
+              RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
           SQL
-        )
+          adapter.create_trigger(
+            <<-SQL,
+              CREATE TRIGGER uppercase_users_name
+                  BEFORE INSERT ON users
+                  FOR EACH ROW
+                  EXECUTE PROCEDURE uppercase_users_name();
+            SQL
+          )
 
-        expect(adapter.functions.map(&:name)).to eq ["test"]
+          expect(adapter.triggers.map(&:name)).to include("uppercase_users_name")
+        end
       end
-    end
 
-    describe "#triggers" do
-      it "finds triggers and builds Fx::Trigger objects" do
-        connection.execute <<-SQL
-          CREATE TABLE users (
-              id int PRIMARY KEY,
-              name varchar(256),
-              upper_name varchar(256)
-          );
-        SQL
-        adapter = Postgres.new
-        adapter.create_function <<-SQL
-          CREATE OR REPLACE FUNCTION uppercase_users_name()
-          RETURNS trigger AS $$
-          BEGIN
-            NEW.upper_name = UPPER(NEW.name);
-            RETURN NEW;
-          END;
-          $$ LANGUAGE plpgsql;
-        SQL
-        sql_definition = <<-SQL
-          CREATE TRIGGER uppercase_users_name
-              BEFORE INSERT ON users
-              FOR EACH ROW
-              EXECUTE PROCEDURE uppercase_users_name()
-        SQL
-        adapter.create_trigger(sql_definition)
+      describe "#drop_function" do
+        context "when the function has arguments" do
+          it "successfully drops a function with the entire function signature" do
+            adapter = Postgres.new
+            adapter.create_function(
+              <<-SQL,
+                CREATE FUNCTION adder(x int, y int)
+                RETURNS int AS $$
+                BEGIN
+                    RETURN $1 + $2;
+                END;
+                $$ LANGUAGE plpgsql;
+              SQL
+            )
 
-        expect(adapter.triggers.map(&:name)).to eq ["uppercase_users_name"]
+            adapter.drop_function(:adder)
+
+            expect(adapter.functions.map(&:name)).not_to include("adder")
+          end
+        end
+
+        context "when the function does not have arguments" do
+          it "successfully drops a function" do
+            adapter = Postgres.new
+            adapter.create_function(
+              <<-SQL,
+                CREATE OR REPLACE FUNCTION test()
+                RETURNS text AS $$
+                BEGIN
+                    RETURN 'test';
+                END;
+                $$ LANGUAGE plpgsql;
+              SQL
+            )
+
+            adapter.drop_function(:test)
+
+            expect(adapter.functions.map(&:name)).not_to include("test")
+          end
+        end
+      end
+
+      describe "#functions" do
+        it "finds functions and builds Fx::Function objects" do
+          adapter = Postgres.new
+          adapter.create_function(
+            <<-SQL,
+              CREATE OR REPLACE FUNCTION test()
+              RETURNS text AS $$
+              BEGIN
+                  RETURN 'test';
+              END;
+              $$ LANGUAGE plpgsql;
+            SQL
+          )
+
+          expect(adapter.functions.map(&:name)).to eq ["test"]
+        end
+      end
+
+      describe "#triggers" do
+        it "finds triggers and builds Fx::Trigger objects" do
+          connection.execute <<-SQL
+            CREATE TABLE users (
+                id int PRIMARY KEY,
+                name varchar(256),
+                upper_name varchar(256)
+            );
+          SQL
+          adapter = Postgres.new
+          adapter.create_function <<-SQL
+            CREATE OR REPLACE FUNCTION uppercase_users_name()
+            RETURNS trigger AS $$
+            BEGIN
+              NEW.upper_name = UPPER(NEW.name);
+              RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+          SQL
+          sql_definition = <<-SQL
+            CREATE TRIGGER uppercase_users_name
+                BEFORE INSERT ON users
+                FOR EACH ROW
+                EXECUTE PROCEDURE uppercase_users_name()
+          SQL
+          adapter.create_trigger(sql_definition)
+
+          expect(adapter.triggers.map(&:name)).to eq ["uppercase_users_name"]
+        end
       end
     end
   end

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -6,7 +6,7 @@ module Fx::Adapters
       it "successfully creates a function" do
         adapter = Postgres.new
         adapter.create_function(
-          <<-SQL
+          <<-SQL,
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
@@ -40,7 +40,7 @@ module Fx::Adapters
           $$ LANGUAGE plpgsql;
         SQL
         adapter.create_trigger(
-          <<-SQL
+          <<-SQL,
             CREATE TRIGGER uppercase_users_name
                 BEFORE INSERT ON users
                 FOR EACH ROW
@@ -57,7 +57,7 @@ module Fx::Adapters
         it "successfully drops a function with the entire function signature" do
           adapter = Postgres.new
           adapter.create_function(
-            <<-SQL
+            <<-SQL,
               CREATE FUNCTION adder(x int, y int)
               RETURNS int AS $$
               BEGIN
@@ -77,7 +77,7 @@ module Fx::Adapters
         it "successfully drops a function" do
           adapter = Postgres.new
           adapter.create_function(
-            <<-SQL
+            <<-SQL,
               CREATE OR REPLACE FUNCTION test()
               RETURNS text AS $$
               BEGIN
@@ -98,7 +98,7 @@ module Fx::Adapters
       it "finds functions and builds Fx::Function objects" do
         adapter = Postgres.new
         adapter.create_function(
-          <<-SQL
+          <<-SQL,
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -49,13 +49,17 @@ module Fx
             SQL
           )
 
-          expect(adapter.triggers.map(&:name)).to include("uppercase_users_name")
+          expect(adapter.triggers.map(&:name)).to include(
+            "uppercase_users_name",
+          )
         end
       end
 
       describe "#drop_function" do
         context "when the function has arguments" do
-          it "successfully drops a function with the entire function signature" do
+          it(
+            "successfully drops a function with the entire function signature",
+          ) do
             adapter = Postgres.new
             adapter.create_function(
               <<-SQL,

--- a/spec/fx/command_recorder/arguments_spec.rb
+++ b/spec/fx/command_recorder/arguments_spec.rb
@@ -1,40 +1,42 @@
 require "spec_helper"
 
-module Fx::CommandRecorder
-  describe Arguments do
-    describe "#function" do
-      it "returns the function name" do
-        raw_args = [:spaceships, { foo: :bar }]
-        args = Arguments.new(raw_args)
+module Fx
+  module CommandRecorder
+    describe Arguments do
+      describe "#function" do
+        it "returns the function name" do
+          raw_args = [:spaceships, { foo: :bar }]
+          args = Arguments.new(raw_args)
 
-        expect(args.function).to eq :spaceships
-      end
-    end
-
-    describe "#revert_to_version" do
-      it "is the revert_to_version from the keyword arguments" do
-        raw_args = [:spaceships, { revert_to_version: 42 }]
-        args = Arguments.new(raw_args)
-
-        expect(args.revert_to_version).to eq 42
+          expect(args.function).to eq :spaceships
+        end
       end
 
-      it "is nil if the revert_to_version was not supplied" do
-        raw_args = [:spaceships, { foo: :bar }]
-        args = Arguments.new(raw_args)
+      describe "#revert_to_version" do
+        it "is the revert_to_version from the keyword arguments" do
+          raw_args = [:spaceships, { revert_to_version: 42 }]
+          args = Arguments.new(raw_args)
 
-        expect(args.revert_to_version).to be nil
+          expect(args.revert_to_version).to eq 42
+        end
+
+        it "is nil if the revert_to_version was not supplied" do
+          raw_args = [:spaceships, { foo: :bar }]
+          args = Arguments.new(raw_args)
+
+          expect(args.revert_to_version).to be nil
+        end
       end
-    end
 
-    describe "#invert_version" do
-      it "returns object with version set to revert_to_version" do
-        raw_args = [:meatballs, { version: 42, revert_to_version: 15 }]
+      describe "#invert_version" do
+        it "returns object with version set to revert_to_version" do
+          raw_args = [:meatballs, { version: 42, revert_to_version: 15 }]
 
-        inverted_args = Arguments.new(raw_args).invert_version
+          inverted_args = Arguments.new(raw_args).invert_version
 
-        expect(inverted_args.version).to eq 15
-        expect(inverted_args.revert_to_version).to be nil
+          expect(inverted_args.version).to eq 15
+          expect(inverted_args.revert_to_version).to be nil
+        end
       end
     end
   end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -4,14 +4,14 @@ describe Fx::Definition do
   describe "#to_sql" do
     context "representing a function definition" do
       it "returns the content of a function definition" do
-        sql_definition = <<-EOS
+        sql_definition = <<-SQL
           CREATE OR REPLACE FUNCTION test()
           RETURNS text AS $$
           BEGIN
               RETURN 'test';
           END;
           $$ LANGUAGE plpgsql;
-        EOS
+        SQL
         allow(File).to receive(:read).and_return(sql_definition)
 
         definition = Fx::Definition.new(name: "test", version: 1)
@@ -31,14 +31,14 @@ describe Fx::Definition do
 
       context "when definition is at Rails engine" do
         it "returns the content of a function definition" do
-          sql_definition = <<-EOS
+          sql_definition = <<-SQL
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
                 RETURN 'test';
             END;
             $$ LANGUAGE plpgsql;
-          EOS
+          SQL
           engine_path = Rails.root.join("tmp", "engine")
           FileUtils.mkdir_p(engine_path.join("db", "functions"))
           File.write(engine_path.join("db", "functions", "custom_test_v01.sql"), sql_definition)
@@ -55,12 +55,12 @@ describe Fx::Definition do
 
     context "representing a trigger definition" do
       it "returns the content of a trigger definition" do
-        sql_definition = <<-EOS
+        sql_definition = <<-SQL
           CREATE TRIGGER check_update
           BEFORE UPDATE ON accounts
           FOR EACH ROW
           EXECUTE PROCEDURE check_account_update();
-        EOS
+        SQL
         allow(File).to receive(:read).and_return(sql_definition)
 
         definition = Fx::Definition.new(

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -41,8 +41,13 @@ describe Fx::Definition do
           SQL
           engine_path = Rails.root.join("tmp", "engine")
           FileUtils.mkdir_p(engine_path.join("db", "functions"))
-          File.write(engine_path.join("db", "functions", "custom_test_v01.sql"), sql_definition)
-          Rails.application.config.paths["db/migrate"].push(engine_path.join("db", "migrate"))
+          File.write(
+            engine_path.join("db", "functions", "custom_test_v01.sql"),
+            sql_definition,
+          )
+          Rails.application.config.paths["db/migrate"].push(
+            engine_path.join("db", "migrate"),
+          )
 
           definition = Fx::Definition.new(name: "custom_test", version: 1)
 

--- a/spec/fx/function_spec.rb
+++ b/spec/fx/function_spec.rb
@@ -44,11 +44,11 @@ module Fx
           "definition" => "CREATE OR REPLACE TRIGGER uppercase_users_name ...",
         )
 
-        expect(function.to_schema).to eq <<-EOS
+        expect(function.to_schema).to eq <<-FUNCTION
   create_function :uppercase_users_name, sql_definition: <<-\SQL
       CREATE OR REPLACE TRIGGER uppercase_users_name ...
   SQL
-        EOS
+        FUNCTION
       end
     end
   end

--- a/spec/fx/schema_dumper/function_spec.rb
+++ b/spec/fx/schema_dumper/function_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe Fx::SchemaDumper::Function, :db do
   it "dumps a create_function for a function in the database" do
-    sql_definition = <<-EOS
+    sql_definition = <<-SQL
       CREATE OR REPLACE FUNCTION test()
       RETURNS text AS $$
       BEGIN
           RETURN 'test';
       END;
       $$ LANGUAGE plpgsql;
-    EOS
+    SQL
     connection.create_function :test, sql_definition: sql_definition
     stream = StringIO.new
 

--- a/spec/fx/schema_dumper/trigger_spec.rb
+++ b/spec/fx/schema_dumper/trigger_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe Fx::SchemaDumper::Trigger, :db do
   it "dumps a create_trigger for a trigger in the database" do
-    connection.execute <<-EOS
+    connection.execute <<-SQL
       CREATE TABLE users (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
       );
-    EOS
-    Fx.database.create_function <<-EOS
+    SQL
+    Fx.database.create_function <<-SQL
       CREATE OR REPLACE FUNCTION uppercase_users_name()
       RETURNS trigger AS $$
       BEGIN
@@ -17,13 +17,13 @@ describe Fx::SchemaDumper::Trigger, :db do
         RETURN NEW;
       END;
       $$ LANGUAGE plpgsql;
-    EOS
-    sql_definition = <<-EOS
+    SQL
+    sql_definition = <<-SQL
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
-    EOS
+    SQL
     connection.create_trigger(
       :uppercase_users_name,
       sql_definition: sql_definition,

--- a/spec/fx/trigger_spec.rb
+++ b/spec/fx/trigger_spec.rb
@@ -44,11 +44,11 @@ module Fx
           "definition" => "CREATE TRIGGER uppercase_users_name ...",
         )
 
-        expect(trigger.to_schema).to eq <<-EOS
+        expect(trigger.to_schema).to eq <<-TRIGGER
   create_trigger :uppercase_users_name, sql_definition: <<-\SQL
       CREATE TRIGGER uppercase_users_name ...
   SQL
-        EOS
+        TRIGGER
       end
     end
   end


### PR DESCRIPTION
When running the `rubocop` version `0.58.0` I ran into
some issues which didn't allow me to see the offenses.

This PR changes the `.rubocop.yml` by updating rules, removing
unrecognized cops, and removing duplicated cops.
This PR also fixes the offenses found by rubocop.

Changes:
- Update `TrailingCommaInLiteral` with new name.
- Update rules with the correct namespace.
- Update rules with the correct parameter.
- Update namespace `Performance/Sample` to `Style/Sample`.
- Move `Style/Sample` rule.
- Remove unrecognized cop `Lint/InvalidCharacterLiteral`.
- Remove unrecognized cop `Lint/LiteralInCondition`.
- Remove unrecognized cop `Lint/UnneededDisable`.
- Remove unrecognized `Performance/*` cops.
- Remove unrecognized cops `Rails/*`.
- Remove duplicated cop.
- Disable cop for `ExpandPathArguments`.
- Disable cop for `EmptyLineAfterMagicComment`.
- Add `required` cop for `MemoizedInstanceVariableName`.
- Update `Lint/FlipFlop` to `Style/FlipFlop`.
- Update `Style/Sample` to `Performance/Sample`.
- Fix unused method arguments.