### PR TITLE
Handle schema-qualified function names

### DIFF
--- a/lib/fx/definition.rb
+++ b/lib/fx/definition.rb
@@ -30,7 +30,7 @@ module Fx
     private
 
     def filename
-      @_filename ||= "#{@name}_v#{version}.sql"
+      @_filename ||= "#{@name.to_s.tr(".", "_")}_v#{version}.sql"
     end
 
     def find_file

--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -78,6 +78,16 @@ module Fx
 
       private
 
+      alias original_file_name file_name
+
+      def file_name
+        original_file_name.tr(".", "_")
+      end
+
+      def singular_name
+        original_file_name
+      end
+
       def function_definition_path
         @_function_definition_path ||= Rails.root.join(*%w(db functions))
       end

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -54,4 +54,21 @@ describe "User manages functions" do
     successfully "rails destroy fx:function adder"
     successfully "rake db:migrate"
   end
+
+  it "handles schema-qualified functions" do
+    execute("CREATE SCHEMA other_schema")
+    successfully "rails generate fx:function other_schema.test"
+    write_function_definition "other_schema_test_v01", <<-EOS
+      CREATE OR REPLACE FUNCTION other_schema.test()
+      RETURNS text AS $$
+      BEGIN
+          RETURN 'test';
+      END;
+      $$ LANGUAGE plpgsql;
+    EOS
+    successfully "rake db:migrate"
+
+    result = execute("SELECT * FROM other_schema.test() AS result")
+    expect(result).to eq("result" => "test")
+  end
 end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -95,6 +95,12 @@ describe Fx::Definition do
 
         expect(definition.path).to eq "db/functions/test_v01.sql"
       end
+
+      it "handles schema-qualified function names" do
+        definition = Fx::Definition.new(name: "other_schema.test", version: 1)
+
+        expect(definition.path).to eq "db/functions/other_schema_test_v01.sql"
+      end
     end
 
     context "representing a trigger definition" do

--- a/spec/generators/fx/function/function_generator_spec.rb
+++ b/spec/generators/fx/function/function_generator_spec.rb
@@ -13,6 +13,17 @@ describe Fx::Generators::FunctionGenerator, :generator do
     expect(migration_file(migration)).to contain "CreateFunctionTest"
   end
 
+  it "handles schema-qualified functions" do
+    migration = file("db/migrate/create_function_other_schema_test.rb")
+    function_definition = file("db/functions/other_schema_test_v01.sql")
+
+    run_generator ["other_schema.test"]
+
+    expect(function_definition).to exist
+    expect(migration).to be_a_migration
+    expect(migration_file(migration)).to contain "CreateFunctionOtherSchemaTest"
+  end
+
   it "updates an existing function" do
     with_function_definition(
       name: "test",


### PR DESCRIPTION
Updates the function generator and the `Fx::Definition` so that schema-qualified function names can be specified.