### PR TITLE
Use db connection provided by Rails

### DIFF
--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -159,7 +159,8 @@ module Fx
         # https://www.postgresql.org/docs/9.6/sql-dropfunction.html
         # https://www.postgresql.org/docs/10/sql-dropfunction.html
 
-        PG.connect.server_version >= 10_00_00
+        pg_connection = connectable.connection.raw_connection
+        pg_connection.server_version >= 10_00_00
       end
     end
   end


### PR DESCRIPTION
First off, just want to say thanks for creating this gem -- I'm excited to use it in my project!

I might be strange, but on my dev machine I don't have a postgres database for my user (i.e., if I just type `psql` at the console, I get an error "psql: FATAL:  database "ryan" does not exist"). I have to specify the dbname. Because of this, I get an error when the code attempt to check the postgres server version. 

I wasn't sure what a good way to build a test for this would be without impacting the dev machine (I don't want to drop anyone's DB!), so I did not include an update to any spec file. However, before the change, specs fail for me. With the change, I'm green.

Looking forward to any comments/feedback on this change. Thanks again and commit body below:

------

Using the Rails db connection ensures we use valid database connection
information when checking the postgres server version.

Without specifying credentials, `PG` attempts to connect to the default
database (i.e., the default one for the current user) which, if it does
not exist, causes an error:

```
  Failure/Error: PG.connect.server_version >= 10_00_00

  PG::ConnectionBad:
    FATAL:  database "xxxxx" does not exist
```

By accessing the raw connection through `@connectable`, we avoid this
issue because we end up using the database configuration as specified by
the Rails app.
