### PR TITLE
Fix outputting escapes in schema output

### DIFF
--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -18,7 +18,7 @@ module Fx
     def to_schema
       <<-SCHEMA.indent(2)
 create_function :#{name}, sql_definition: <<-\SQL
-#{definition.indent(4).rstrip}
+#{definition.indent(4).rstrip.gsub("\\", "\\\\\\\\")}
 SQL
       SCHEMA
     end

--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -2,6 +2,9 @@ module Fx
   # @api private
   class Function
     include Comparable
+    ESCAPE_MAP = {
+      '\\' => '\\\\',
+    }.freeze
 
     attr_reader :name, :definition
     delegate :<=>, to: :name
@@ -18,7 +21,7 @@ module Fx
     def to_schema
       <<-SCHEMA.indent(2)
 create_function :#{name}, sql_definition: <<-\SQL
-#{definition.indent(4).rstrip.gsub("\\", "\\\\\\\\")}
+#{definition.indent(4).rstrip.gsub('\\', ESCAPE_MAP)}
 SQL
       SCHEMA
     end

--- a/spec/fx/function_spec.rb
+++ b/spec/fx/function_spec.rb
@@ -50,6 +50,19 @@ module Fx
   SQL
         EOS
       end
+
+      it "maintains escaped backslashes" do
+        function = Function.new(
+          "name" => "uppercase_users_name",
+          "definition" => "\\x00",
+        )
+
+        expect(function.to_schema).to eq <<-EOS
+  create_function :uppercase_users_name, sql_definition: <<-\SQL
+      \\\\x00
+  SQL
+        EOS
+      end
     end
   end
 end


### PR DESCRIPTION
Update `Function#to_schema` in order to generate schema output that
maintains escapes appropriately.

For example, say you have a function that includes an escape sequence,
such as the popular `naturalsort` function (source
http://www.rhodiumtoad.org.uk/junk/naturalsort.sql):

```
create or replace function naturalsort(text)
  returns bytea
  language sql
  immutable strict
as $f$
  select string_agg(convert_to(coalesce(r[2],
      length(length(r[1])::text) || length(r[1])::text || r[1]),
      'SQL_ASCII'),'\x00')
    from regexp_matches($1, '0*([0-9]+)|([^0-9]+)', 'g') r;
$f$;
```

Note the null byte `\x00`. Simply printing the function definition to
the schema causes issues as, when a user performs `rails
db:schema:load`, Rails complains: "ArgumentError: string contains null
byte."

In order to prevent Rails from interpreting the string as having a null
byte in the middle of the string, resulting in an `ArgumentError`, we
escape the null byte. This results in Rails being able to load the
string to and to create the function appropriately.

I further tested this change by directly checking Postgres' definition
of the function with `\df+ {functionname}`.