### PR TITLE
Support `table_name` variable in triggers sql definition

### DIFF
--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -46,6 +46,16 @@ module Fx
           type: DEFINTION_TYPE,
         ).to_sql
 
+        begin
+          interpolate_params = on ? { table_name: on } : {}
+          sql_definition = sql_definition % interpolate_params if sql_definition
+        rescue KeyError
+          raise(
+            ArgumentError,
+            "`on` option required for sql definition with `table_name` variable"
+          )
+        end
+
         Fx.database.create_trigger(sql_definition)
       end
 
@@ -123,6 +133,8 @@ module Fx
           version: version,
           type: DEFINTION_TYPE,
         ).to_sql
+
+        sql_definition = sql_definition % { table_name: on } if sql_definition && on
 
         Fx.database.update_trigger(
           name,


### PR DESCRIPTION
### Parametrized trigger support for #55 

After this PR users can use parametrized triggers. For example:
```ruby
#migration
class CreateTriggersUpdateStateChangedAt < ActiveRecord::Migration[5.0]
  def change
    create_trigger :update_state_changed_at, params: { table_name: :users }
  end
end
```

```sql
# trigger 
CREATE TRIGGER update_state_changed_at
    BEFORE UPDATE ON %{table_name}
    FOR EACH ROW
    WHEN (OLD.state <> NEW.state)
EXECUTE PROCEDURE update_state_changed_at();
```

I think that **you should remove legacy `on` option in another** PR if you want. I think that removing this option can bad affect for current users of gem.

Sorry for not adding instructions to readme. I have no enough English for it :( 
