### PR TITLE
Support --no-migration generator flag

### DIFF
--- a/lib/generators/fx/function/USAGE
+++ b/lib/generators/fx/function/USAGE
@@ -2,6 +2,8 @@ Description:
   Create a new database function for your application. This will create a new
   function definition file and the accompanying migration.
 
+  When --no-migration is passed, skips generating a migration.
+
 Examples:
     rails generate fx:function test
 

--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -8,6 +8,8 @@ module Fx
       include Rails::Generators::Migration
       source_root File.expand_path("../templates", __FILE__)
 
+      class_option :migration, type: :boolean
+
       def create_functions_directory
         unless function_definition_path.exist?
           empty_directory(function_definition_path)
@@ -23,6 +25,7 @@ module Fx
       end
 
       def create_migration_file
+        return if skip_migration_creation?
         if updating_existing_function?
           migration_template(
             "db/migrate/update_function.erb",
@@ -100,6 +103,16 @@ module Fx
 
       def previous_definition
         Fx::Definition.new(name: file_name, version: previous_version)
+      end
+
+      # Skip creating migration file if:
+      #   - migrations option is nil or false
+      def skip_migration_creation?
+        !migration
+      end
+
+      def migration
+        options[:migration]
       end
     end
   end

--- a/lib/generators/fx/trigger/USAGE
+++ b/lib/generators/fx/trigger/USAGE
@@ -5,6 +5,8 @@ Description:
   If a trigger of the given name already exists, create a new version of the
   trigger and a migration to replace the old version with the new.
 
+  When --no-migration is passed, skips generating a migration.
+
 Examples:
 
     rails generate fx:trigger test

--- a/lib/generators/fx/trigger/trigger_generator.rb
+++ b/lib/generators/fx/trigger/trigger_generator.rb
@@ -9,6 +9,8 @@ module Fx
       source_root File.expand_path("../templates", __FILE__)
       argument :table_name, type: :hash, required: true
 
+      class_option :migration, type: :boolean
+
       def create_triggers_directory
         unless trigger_definition_path.exist?
           empty_directory(trigger_definition_path)
@@ -20,6 +22,7 @@ module Fx
       end
 
       def create_migration_file
+        return if skip_migration_creation?
         if updating_existing_trigger?
           migration_template(
             "db/migrate/update_trigger.erb",
@@ -110,6 +113,16 @@ module Fx
 
       def trigger_definition_path
         @_trigger_definition_path ||= Rails.root.join(*["db", "triggers"])
+      end
+
+      # Skip creating migration file if:
+      #   - migrations option is nil or false
+      def skip_migration_creation?
+        !migration
+      end
+
+      def migration
+        options[:migration]
       end
     end
   end

--- a/spec/generators/fx/function/function_generator_spec.rb
+++ b/spec/generators/fx/function/function_generator_spec.rb
@@ -13,6 +13,18 @@ describe Fx::Generators::FunctionGenerator, :generator do
     expect(migration_file(migration)).to contain "CreateFunctionTest"
   end
 
+  context "when passed --no-migration" do
+    it "creates a only function definition file" do
+      migration = file("db/migrate/create_function_test.rb")
+      function_definition = file("db/functions/test_v01.sql")
+
+      run_generator ["test", "--no-migration"]
+
+      expect(function_definition).to exist
+      expect(migration_file(migration)).not_to exist
+    end
+  end
+
   it "updates an existing function" do
     with_function_definition(
       name: "test",

--- a/spec/generators/fx/trigger/trigger_generator_spec.rb
+++ b/spec/generators/fx/trigger/trigger_generator_spec.rb
@@ -14,6 +14,18 @@ describe Fx::Generators::TriggerGenerator, :generator do
     expect(migration_file(migration)).to contain "on: :some_table"
   end
 
+  context "when passed --no-migration" do
+    it "creates a only trigger definition file" do
+      migration = file("db/migrate/create_trigger_test.rb")
+      trigger_definition = file("db/triggers/test_v01.sql")
+
+      run_generator ["test", "--no-migration"]
+
+      expect(trigger_definition).to exist
+      expect(migration_file(migration)).not_to exist
+    end
+  end
+
   it "supports naming the table as `on` aswell as `table_name`" do
     migration = file("db/migrate/create_trigger_test.rb")
     trigger_definition = file("db/triggers/test_v01.sql")


### PR DESCRIPTION
Based on Rails [Model generator](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/rails/generators/active_record/model/model_generator.rb#L12)

I couldn't get the test suite to run locally

My use case is mostly that I'm just starting to use fx in my project and most of the time I want to generator a v1 before I use fx to change it, and I keep having to delete the migrations generated