### PR TITLE
Fix: Support --no-migration generator flag

### DIFF
--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -111,8 +111,9 @@ module Fx
         !migration
       end
 
+      # True unless explicitly false
       def migration
-        options[:migration]
+        options[:migration] != false
       end
     end
   end

--- a/lib/generators/fx/trigger/trigger_generator.rb
+++ b/lib/generators/fx/trigger/trigger_generator.rb
@@ -121,8 +121,9 @@ module Fx
         !migration
       end
 
+      # True unless explicitly false
       def migration
-        options[:migration]
+        options[:migration] != false
       end
     end
   end

--- a/spec/generators/fx/trigger/trigger_generator_spec.rb
+++ b/spec/generators/fx/trigger/trigger_generator_spec.rb
@@ -19,7 +19,7 @@ describe Fx::Generators::TriggerGenerator, :generator do
       migration = file("db/migrate/create_trigger_test.rb")
       trigger_definition = file("db/triggers/test_v01.sql")
 
-      run_generator ["test", "--no-migration"]
+      run_generator ["test", {"table_name" => "some_table"}, "--no-migration"]
 
       expect(trigger_definition).to exist
       expect(migration_file(migration)).not_to exist


### PR DESCRIPTION
- Fix impl and tests in https://github.com/teoljungberg/fx/pull/60

I figured out how to run the tests (on reflection, it's not hard, so don't know what my issue was before, maybe just appraisal

basically I (on Ruby 2.6.2)

```sh
export BUNDLE_GEMFILE=gemfiles/rails60.gemfile
gem install bundler --conservative
bundle check || bundle install
bundle exec rake dummy:db:drop
bundle exec rake dummy:db:create
bundle exec rake
```