### PR TITLE
Expose migration methods for getting the sql definition

### DIFF
--- a/lib/fx/statements/function.rb
+++ b/lib/fx/statements/function.rb
@@ -37,7 +37,7 @@ module Fx
           )
         end
         sql_definition = sql_definition.strip_heredoc if sql_definition
-        sql_definition ||= Fx::Definition.new(name: name, version: version).to_sql
+        sql_definition ||= function_sql(name, version: version)
 
         Fx.database.create_function(sql_definition)
       end
@@ -95,12 +95,16 @@ module Fx
         end
 
         sql_definition = sql_definition.strip_heredoc if sql_definition
-        sql_definition ||= Fx::Definition.new(
+        sql_definition ||= function_sql(name, version: version)
+
+        Fx.database.update_function(name, sql_definition)
+      end
+
+      def function_sql(name, version:)
+        ::Fx::Definition.new(
           name: name,
           version: version,
         ).to_sql
-
-        Fx.database.update_function(name, sql_definition)
       end
     end
   end

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -40,11 +40,7 @@ module Fx
         end
 
         sql_definition = sql_definition.strip_heredoc if sql_definition
-        sql_definition ||= Fx::Definition.new(
-          name: name,
-          version: version,
-          type: DEFINTION_TYPE,
-        ).to_sql
+        sql_definition ||= trigger_sql(name, version: version)
 
         Fx.database.create_trigger(sql_definition)
       end
@@ -118,17 +114,21 @@ module Fx
         end
 
         sql_definition = sql_definition.strip_heredoc if sql_definition
-        sql_definition ||= Fx::Definition.new(
-          name: name,
-          version: version,
-          type: DEFINTION_TYPE,
-        ).to_sql
+        sql_definition ||= trigger_sql(name, version: version)
 
         Fx.database.update_trigger(
           name,
           on: on,
           sql_definition: sql_definition,
         )
+      end
+
+      def trigger_sql(name, version:)
+        Fx::Definition.new(
+          name: name,
+          version: version,
+          type: DEFINTION_TYPE,
+        ).to_sql
       end
     end
   end

--- a/spec/fx/statements/function_spec.rb
+++ b/spec/fx/statements/function_spec.rb
@@ -27,6 +27,17 @@ describe Fx::Statements::Function, :db do
         with(name: :test, version: 2)
     end
 
+    it "get the function sql from a file" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.function_sql(:test, version: 1)
+
+      expect(definition).to have_received(:to_sql)
+      expect(Fx::Definition).to have_received(:new).
+        with(name: :test, version: 1)
+    end
+
     it "raises an error if both arguments are nil" do
       expect {
         connection.create_function(

--- a/spec/fx/statements/trigger_spec.rb
+++ b/spec/fx/statements/trigger_spec.rb
@@ -27,6 +27,17 @@ describe Fx::Statements::Trigger, :db do
         with(name: :test, version: 2, type: "trigger")
     end
 
+    it "get the trigger sql from a file" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.trigger_sql(:test, version: 1)
+
+      expect(definition).to have_received(:to_sql)
+      expect(Fx::Definition).to have_received(:new).
+        with(name: :test, version: 1, type: "trigger")
+    end
+
     it "raises an error if both arguments are set" do
       stubbed_database
 


### PR DESCRIPTION
Useful when you want to interact with the sql in various ways.

<Details>

<Summary>
For example, I use `strong_migrations`, so I made a mixin for all my
migrations to get the function sql.
</Summary>

```ruby
  # Could be simplified after https://github.com/teoljungberg/fx/pull/52 is merged
  def db_update_function(function_name, version:, revert_to_version:, replace: true)
    if replace
      reversible do |dir|
        dir.up do
          safely_execute function_sql(function_name, version: version)
        end
        dir.down do
          safely_execute function_sql(function_name, version: revert_to_version)
        end
      end
    else
      safety_assured do
        update_function function_name version: version, revert_to_version: revert_to_version
      end
    end
  end
```

</Details>

I expect you may want a different name for the methods than
`function_sql` and `trigger_sql`, but am using that as a discussion
point.  Notably, even though the trigger generator requires a table
name, it doesn't appear to be used.  (I've noticed an old issue regarding
this.)

Tests pass. `bin/setup; bin/appraisal rake` on CRuby 2.6.2.