### PR TITLE
Support for ruby 3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,6 +2,7 @@ appraise "rails42" do
   gem "activerecord", "~> 4.2.0"
   gem "railties", "~> 4.2.0"
   gem "pg", "~> 0.15"
+  gem "bigdecimal", '1.3.5'
 end
 
 if RUBY_VERSION > "2.2.0"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.2.0"
 gem "railties", "~> 4.2.0"
 gem "pg", "~> 0.15"
+gem "bigdecimal", "1.3.5"
 
 gemspec path: "../"

--- a/lib/fx/statements/function.rb
+++ b/lib/fx/statements/function.rb
@@ -29,7 +29,10 @@ module Fx
       #     $$ LANGUAGE plpgsql;
       #   SQL
       #
-      def create_function(name, version: 1, sql_definition: nil)
+      def create_function(name, options = {})
+        version = options.fetch(:version, 1)
+        sql_definition = options[:sql_definition]
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,
@@ -53,7 +56,8 @@ module Fx
       # @example Drop a function, rolling back to version 2 on rollback
       #   drop_function(:uppercase_users_name, revert_to_version: 2)
       #
-      def drop_function(name, revert_to_version: nil)
+      def drop_function(name, options = {})
+        revert_to_version = options[:revert_to_version]
         Fx.database.drop_function(name)
       end
 
@@ -86,7 +90,11 @@ module Fx
       #     $$ LANGUAGE plpgsql;
       #   SQL
       #
-      def update_function(name, version: nil, sql_definition: nil, revert_to_version: nil)
+      def update_function(name, options = {})
+        version = options[:version]
+        sql_definition = options[:sql_definition]
+        revert_to_version = options[:revert_to_version]
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -27,7 +27,10 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      def create_trigger(name, version: nil, on: nil, sql_definition: nil)
+      def create_trigger(name, options = {})
+       version = options[:version]
+       on = options[:on]
+       sql_definition = options[:sql_definition]
         if version.present? && sql_definition.present?
           raise(
             ArgumentError,
@@ -62,7 +65,9 @@ module Fx
       # @example Drop a trigger, rolling back to version 3 on rollback
       #   drop_trigger(:log_inserts, on: :users, revert_to_version: 3)
       #
-      def drop_trigger(name, on:, revert_to_version: nil)
+      def drop_trigger(name, options = {})
+        on = options.fetch(:on)
+        revert_to_version = options[:revert_to_version]
         Fx.database.drop_trigger(name, on: on)
       end
 
@@ -98,7 +103,12 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      def update_trigger(name, version: nil, on: nil, sql_definition: nil, revert_to_version: nil)
+      # def update_trigger(name, version: nil, on: nil, sql_definition: nil, revert_to_version: nil)
+      def update_trigger(name, options = {})
+        version = options[:version]
+        on = options[:on]
+        sql_definition = options[:sql_definition]
+        revert_to_version = options[:revert_to_version]
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -103,7 +103,6 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      # def update_trigger(name, version: nil, on: nil, sql_definition: nil, revert_to_version: nil)
       def update_trigger(name, options = {})
         version = options[:version]
         on = options[:on]


### PR DESCRIPTION
Hi

This is my intent to fix ArgumentError: wrong number of arguments (given 2, expected 1; required keyword: on) for ruby 3 reported in  #65,  also fixes the failing tests for rails 4.2.

In my local two tests fails: `spec/fx/adapters/postgres/triggers_spec.rb:7` and `spec/fx/schema_dumper/trigger_spec.rb:4`, but I hope is because postgres version, I have postgres 12 installed.
