### PR TITLE
Preserve backslashes when dumping the schema

### DIFF
--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -17,7 +17,7 @@ module Fx
 
     def to_schema
       <<-SCHEMA.indent(2)
-create_function :#{name}, sql_definition: <<-\SQL
+create_function :#{name}, sql_definition: <<-'SQL'
 #{definition.indent(4).rstrip}
 SQL
       SCHEMA

--- a/spec/fx/function_spec.rb
+++ b/spec/fx/function_spec.rb
@@ -44,9 +44,22 @@ module Fx
           "definition" => "CREATE OR REPLACE TRIGGER uppercase_users_name ...",
         )
 
-        expect(function.to_schema).to eq <<-EOS
-  create_function :uppercase_users_name, sql_definition: <<-\SQL
+        expect(function.to_schema).to eq <<-'EOS'
+  create_function :uppercase_users_name, sql_definition: <<-'SQL'
       CREATE OR REPLACE TRIGGER uppercase_users_name ...
+  SQL
+        EOS
+      end
+
+      it "maintains backslashes" do
+        function = Function.new(
+          "name" => "regex",
+          "definition" => "CREATE OR REPLACE FUNCTION regex \\1",
+        )
+
+        expect(function.to_schema).to eq <<-'EOS'
+  create_function :regex, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION regex \1
   SQL
         EOS
       end

--- a/spec/fx/schema_dumper/function_spec.rb
+++ b/spec/fx/schema_dumper/function_spec.rb
@@ -71,7 +71,7 @@ describe Fx::SchemaDumper::Function, :db do
     ActiveRecord::SchemaDumper.dump(connection, stream)
 
     output = stream.string
-    expect(output).to include "create_function :test, sql_definition: <<-SQL"
+    expect(output).to include "create_function :test, sql_definition: <<-'SQL'"
     expect(output).to include "RETURN 'test';"
     expect(output).not_to include "aggregate_test"
   end


### PR DESCRIPTION
This is an alternative to https://github.com/teoljungberg/fx/pull/51 that fixes the same problem, but in a way that is more obviously-correct.

If a Postgres function contains backslashes (common in regexes e.g. \s
or \1), then we write those backslashes into a heredoc in schema.rb
without escaping them. So if you load your database from schema.rb, ruby
interprets the backslashes instead of preserving them for Postgres.
Rather than trying to escape every possible thing, this commit uses a
single-quote heredoc (<<-'SQL') which treats all characters literally.