### PR TITLE
Support Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ language:
 notifications:
   email: false
 rvm:
+  - 3.0
   - 2.7
   - 2.6
   - 2.5
@@ -49,3 +50,11 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.7
       gemfile: gemfiles/rails42.gemfile
+    - rvm: 3.0
+      gemfile: gemfiles/rails42.gemfile
+    - rvm: 3.0
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: 3.0
+      gemfile: gemfiles/rails51.gemfile
+    - rvm: 3.0
+      gemfile: gemfiles/rails52.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -3,10 +3,11 @@ if RUBY_VERSION < "2.6.0"
     gem "activerecord", "~> 4.2.0"
     gem "railties", "~> 4.2.0"
     gem "pg", "~> 0.15.0"
+    gem "bigdecimal", "1.3.5"
   end
 end
 
-if RUBY_VERSION >= "2.2.0"
+if RUBY_VERSION >= "2.2.0" and RUBY_VERSION < "3.0.0"
   appraise "rails50" do
     gem "activerecord", "~> 5.0.0"
     gem "railties", "~> 5.0.0"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
 gem "railties", "~> 4.2.0"
-gem "pg", "~> 0.15"
+gem "pg", "~> 0.15.0"
+gem "bigdecimal", "1.3.5"
 
 gemspec path: "../"

--- a/lib/fx/statements/function.rb
+++ b/lib/fx/statements/function.rb
@@ -29,7 +29,10 @@ module Fx
       #     $$ LANGUAGE plpgsql;
       #   SQL
       #
-      def create_function(name, version: 1, sql_definition: nil)
+      def create_function(name, options = {})
+        version = options.fetch(:version, 1)
+        sql_definition = options[:sql_definition]
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,
@@ -53,7 +56,8 @@ module Fx
       # @example Drop a function, rolling back to version 2 on rollback
       #   drop_function(:uppercase_users_name, revert_to_version: 2)
       #
-      def drop_function(name, revert_to_version: nil)
+      def drop_function(name, options = {})
+        revert_to_version = options[:revert_to_version]
         Fx.database.drop_function(name)
       end
 
@@ -86,7 +90,11 @@ module Fx
       #     $$ LANGUAGE plpgsql;
       #   SQL
       #
-      def update_function(name, version: nil, sql_definition: nil, revert_to_version: nil)
+      def update_function(name, options = {})
+        version = options[:version]
+        sql_definition = options[:sql_definition]
+        revert_to_version = options[:revert_to_version]
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -27,7 +27,11 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      def create_trigger(name, version: nil, on: nil, sql_definition: nil)
+      def create_trigger(name, options = {})
+        version = options[:version]
+        _on = options[:on]
+        sql_definition = options[:sql_definition]
+
         if version.present? && sql_definition.present?
           raise(
             ArgumentError,
@@ -62,7 +66,9 @@ module Fx
       # @example Drop a trigger, rolling back to version 3 on rollback
       #   drop_trigger(:log_inserts, on: :users, revert_to_version: 3)
       #
-      def drop_trigger(name, on:, revert_to_version: nil)
+      def drop_trigger(name, options = {})
+        on = options.fetch(:on)
+        revert_to_version = options[:revert_to_version]
         Fx.database.drop_trigger(name, on: on)
       end
 
@@ -98,7 +104,12 @@ module Fx
       #         EXECUTE PROCEDURE uppercase_users_name();
       #    SQL
       #
-      def update_trigger(name, version: nil, on: nil, sql_definition: nil, revert_to_version: nil)
+      def update_trigger(name, options = {})
+        version = options[:version]
+        on = options[:on]
+        sql_definition = options[:sql_definition]
+        revert_to_version = options[:revert_to_version]
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,


### PR DESCRIPTION
The biggest change in Ruby 3 is [how keyword parameters are distinct
from positional parameters][1]. If we want to support 3 and pre-3, we
need to take a single hash as a positional parameter (`option = {}`). If
we use the `**option` syntax then things fail on the Ruby 3/Rails 6
combo because of how Rails calls our methods.

I also updated the Travis & Appraisal files. There is no need to support
Rails pre-6 on Ruby 3, since [Rails itself has no plans to support
it][2].

[1]: https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments
[2]: https://github.com/rails/rails/issues/40938