### PR TITLE
Add support to the use of table_name_prefix or table_name_suffix

### DIFF
--- a/lib/fx.rb
+++ b/lib/fx.rb
@@ -4,6 +4,7 @@ require "fx/command_recorder"
 require "fx/configuration"
 require "fx/definition"
 require "fx/function"
+require "fx/migration"
 require "fx/statements"
 require "fx/schema_dumper"
 require "fx/trigger"
@@ -30,6 +31,11 @@ module Fx
     ActiveRecord::ConnectionAdapters::AbstractAdapter.send(
       :include,
       Fx::Statements,
+    )
+
+    ActiveRecord::Migration.send(
+      :include,
+      Fx::Migration,
     )
   end
 

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -142,7 +142,7 @@ module Fx
       #
       # @return [void]
       def drop_trigger(name, on:)
-        execute "DROP TRIGGER #{name} ON #{on};"
+        execute "DROP TRIGGER #{name} ON \"#{on}\";"
       end
 
       private

--- a/lib/fx/migration.rb
+++ b/lib/fx/migration.rb
@@ -1,0 +1,31 @@
+require "rails"
+
+module Fx
+  # @api private
+  module Migration
+
+    def fx_migration_action(*arguments, &block)
+      _method = __callee__
+      arg_list = arguments.map(&:inspect) * ", "
+
+      say_with_time "#{_method}(#{arg_list})" do
+        unless connection.respond_to? :revert
+          if !arguments.empty? && [:drop_trigger, :update_trigger].include?(_method)
+            if arguments.second.is_a?(Hash) && arguments.second.key?(:on)
+              on_table = arguments[1][:on]
+              arguments[1] = arguments.second.merge(on: proper_table_name(on_table, table_name_options))
+            end
+          end
+        end
+        return super unless connection.respond_to?(_method)
+        connection.send(_method, *arguments, &block)
+      end
+    end
+    alias_method :create_function, :fx_migration_action
+    alias_method :drop_function, :fx_migration_action
+    alias_method :update_function, :fx_migration_action
+    alias_method :create_trigger, :fx_migration_action
+    alias_method :drop_trigger, :fx_migration_action
+    alias_method :update_trigger, :fx_migration_action
+  end
+end

--- a/spec/acceptance/user_manages_triggers_spec.rb
+++ b/spec/acceptance/user_manages_triggers_spec.rb
@@ -1,6 +1,13 @@
 require "acceptance_helper"
 
 describe "User manages triggers" do
+  let(:table_name_prefix) { TABLE_NAME_PREFIX }
+  let(:table_name_suffix) { TABLE_NAME_SUFFIX }
+
+  def full_table_name(table_name)
+    "#{table_name_prefix}#{table_name}#{table_name_suffix}"
+  end
+
   it "handles simple triggers" do
     successfully "rails generate model user name:string upper_name:string"
     successfully "rails generate fx:function uppercase_users_name"
@@ -16,36 +23,36 @@ describe "User manages triggers" do
     successfully "rails generate fx:trigger uppercase_users_name table_name:users"
     write_trigger_definition "uppercase_users_name_v01", <<-EOS
       CREATE TRIGGER uppercase_users_name
-          BEFORE INSERT ON users
+          BEFORE INSERT ON "#{full_table_name('users')}"
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
     EOS
     successfully "rake db:migrate"
 
     execute <<-EOS
-      INSERT INTO users
+      INSERT INTO "#{full_table_name('users')}"
       (name, created_at, updated_at)
       VALUES
       ('Bob', NOW(), NOW());
     EOS
-    result = execute("SELECT upper_name FROM users WHERE name = 'Bob';")
+    result = execute("SELECT upper_name FROM \"#{full_table_name('users')}\" WHERE name = 'Bob';")
     expect(result).to eq("upper_name" => "BOB")
 
     successfully "rails generate fx:trigger uppercase_users_name table_name:users"
     write_trigger_definition "uppercase_users_name_v02", <<-EOS
       CREATE TRIGGER uppercase_users_name
-          BEFORE UPDATE ON users
+          BEFORE UPDATE ON "#{full_table_name('users')}"
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
     EOS
     successfully "rake db:migrate"
     execute <<-EOS
-      UPDATE users
+      UPDATE "#{full_table_name('users')}"
       SET name = 'Alice'
       WHERE id = 1;
     EOS
 
-    result = execute("SELECT upper_name FROM users WHERE name = 'Alice';")
+    result = execute("SELECT upper_name FROM \"#{full_table_name('users')}\" WHERE name = 'Alice';")
     expect(result).to eq("upper_name" => "ALICE")
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -6,10 +6,24 @@ require "active_record/railtie"
 Bundler.require(*Rails.groups)
 require "fx"
 
+# Conditionally set table_name_prefix and/or table_name_suffix
+TABLE_NAME_PREFIX = ENV["TABLE_NAME_PREFIX"].presence
+TABLE_NAME_SUFFIX = ENV["TABLE_NAME_SUFFIX"].presence
+
 module Dummy
   class Application < Rails::Application
     config.cache_classes = true
     config.eager_load = false
     config.active_support.deprecation = :stderr
+
+    if TABLE_NAME_PREFIX
+      $stdout.puts "Using table_name_prefix = '#{TABLE_NAME_PREFIX}'"
+      config.active_record.table_name_prefix = TABLE_NAME_PREFIX
+    end
+
+    if TABLE_NAME_SUFFIX
+      $stdout.puts "Using table_name_suffix = '#{TABLE_NAME_SUFFIX}'"
+      config.active_record.table_name_suffix = TABLE_NAME_SUFFIX
+    end
   end
 end

--- a/spec/features/triggers/migrations_spec.rb
+++ b/spec/features/triggers/migrations_spec.rb
@@ -1,9 +1,16 @@
 require "spec_helper"
 
 describe "Trigger migrations", :db do
+  let(:table_name_prefix) { TABLE_NAME_PREFIX }
+  let(:table_name_suffix) { TABLE_NAME_SUFFIX }
+
+  def full_table_name(table_name)
+    "#{table_name_prefix}#{table_name}#{table_name_suffix}"
+  end
+
   around do |example|
     connection.execute <<-EOS
-      CREATE TABLE users (
+      CREATE TABLE "#{full_table_name('users')}" (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
@@ -20,7 +27,7 @@ describe "Trigger migrations", :db do
     EOS
     sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
-          BEFORE INSERT ON users
+          BEFORE INSERT ON "#{full_table_name('users')}"
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
     EOS

--- a/spec/features/triggers/revert_spec.rb
+++ b/spec/features/triggers/revert_spec.rb
@@ -1,9 +1,16 @@
 require "spec_helper"
 
 describe "Reverting migrations", :db do
+  let(:table_name_prefix) { TABLE_NAME_PREFIX }
+  let(:table_name_suffix) { TABLE_NAME_SUFFIX }
+
+  def full_table_name(table_name)
+    "#{table_name_prefix}#{table_name}#{table_name_suffix}"
+  end
+
   around do |example|
     connection.execute <<-EOS
-      CREATE TABLE users (
+      CREATE TABLE "#{full_table_name('users')}" (
           id int PRIMARY KEY,
           name varchar(256),
           upper_name varchar(256)
@@ -20,7 +27,7 @@ describe "Reverting migrations", :db do
     EOS
     sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
-          BEFORE INSERT ON users
+          BEFORE INSERT ON "#{full_table_name('users')}"
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
     EOS
@@ -69,7 +76,7 @@ describe "Reverting migrations", :db do
 
     sql_definition = <<-EOS
       CREATE TRIGGER uppercase_users_name
-          BEFORE UPDATE ON users
+          BEFORE UPDATE ON "#{full_table_name('users')}"
           FOR EACH ROW
           EXECUTE PROCEDURE uppercase_users_name();
     EOS


### PR DESCRIPTION
Hi @teoljungberg I'm opening this PR in order to address issue #81.

I add a new method on the migration stack in order to prevent the `method_missing(method, *arguments, &block)` on the **activerecord** `/lib/active_record/migration.rb` being called. Also tweaks the specs to handle the `full_table_name` when needed. I'm not sure how do you want to address the specs as I added the handling for environment variables in order to test everything when the `table_name_prefix` and/or `table_name_suffix` are used. So all the specs can be run like
```bash
bin/appraisal rake
TABLE_NAME_PREFIX='prefix-' bin/appraisal rake
TABLE_NAME_SUFFIX='-suffix' bin/appraisal rake
```

But not sure if this is what you had in mind? Anything let me know