### PR TITLE
Allow exclusion of some triggers/functions from schema

### DIFF
--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -40,9 +40,25 @@ module Fx
     # @return Boolean
     attr_accessor :dump_functions_at_beginning_of_schema
 
+    # A lambda returning a boolean to indicate whether or not a given trigger
+    # should be allowed to be dumped into schema.rb
+    #
+    # Defaults to a lambda which allows all triggers
+    # @return Proc<Boolean>
+    attr_accessor :exclude_trigger_from_schema_condition
+
+    # A lambda returning a boolean to indicate whether or not a given function
+    # should be allowed to be dumped into schema.rb
+    #
+    # Defaults to a lambda which allows all function
+    # @return Proc<Boolean>
+    attr_accessor :exclude_function_from_schema_condition
+
     def initialize
       @database = Fx::Adapters::Postgres.new
       @dump_functions_at_beginning_of_schema = false
+      @exclude_trigger_from_schema_condition = lambda { |trigger| false }
+      @exclude_function_from_schema_condition = lambda { |function| false }
     end
   end
 end

--- a/lib/fx/schema_dumper/function.rb
+++ b/lib/fx/schema_dumper/function.rb
@@ -31,7 +31,9 @@ module Fx
       private
 
       def dumpable_functions_in_database
-        @_dumpable_functions_in_database ||= Fx.database.functions
+        @_dumpable_functions_in_database ||= Fx.database.functions.reject(
+          &Fx.configuration.exclude_function_from_schema_condition
+        )
       end
     end
   end

--- a/lib/fx/schema_dumper/trigger.rb
+++ b/lib/fx/schema_dumper/trigger.rb
@@ -22,7 +22,9 @@ module Fx
       private
 
       def dumpable_triggers_in_database
-        @_dumpable_triggers_in_database ||= Fx.database.triggers
+        @_dumpable_triggers_in_database ||= Fx.database.triggers.reject(
+          &Fx.configuration.exclude_trigger_from_schema_condition
+        )
       end
     end
   end

--- a/spec/fx/schema_dumper/trigger_spec.rb
+++ b/spec/fx/schema_dumper/trigger_spec.rb
@@ -37,4 +37,77 @@ describe Fx::SchemaDumper::Trigger, :db do
     expect(output).to include "sql_definition: <<-SQL"
     expect(output).to include "EXECUTE PROCEDURE uppercase_users_name()"
   end
+
+  it "dumps only included triggers" do
+    begin
+      Fx.configuration.exclude_trigger_from_schema_condition = lambda do |trigger|
+        trigger.name == "lowercase_users_name"
+      end
+
+      connection.execute <<-EOS
+      CREATE TABLE users (
+          id int PRIMARY KEY,
+          name varchar(256),
+          upper_name varchar(256),
+          lower_name varchar(256)
+      );
+      EOS
+
+      Fx.database.create_function <<-EOS
+      CREATE OR REPLACE FUNCTION uppercase_users_name()
+      RETURNS trigger AS $$
+      BEGIN
+        NEW.upper_name = UPPER(NEW.name);
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      EOS
+
+      Fx.database.create_function <<-EOS
+      CREATE OR REPLACE FUNCTION lowercase_users_name()
+      RETURNS trigger AS $$
+      BEGIN
+        NEW.lower_name = LOWER(NEW.name);
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      EOS
+
+      sql_definition_allowed = <<-EOS
+      CREATE TRIGGER uppercase_users_name
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          EXECUTE PROCEDURE uppercase_users_name();
+      EOS
+
+      sql_definition_disallowed = <<-EOS
+      CREATE TRIGGER lowercase_users_name
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          EXECUTE PROCEDURE lowercase_users_name();
+      EOS
+
+      connection.create_trigger(
+        :uppercase_users_name,
+        sql_definition: sql_definition_allowed,
+      )
+
+      connection.create_trigger(
+        :lowercase_users_name,
+        sql_definition: sql_definition_disallowed,
+      )
+
+      stream = StringIO.new
+
+      ActiveRecord::SchemaDumper.dump(connection, stream)
+
+      output = stream.string
+      expect(output).to include "create_trigger :uppercase_users_name"
+      expect(output).not_to include "create_trigger :lowercase_users_name"
+      expect(output).to include "sql_definition: <<-SQL"
+      expect(output).to include "EXECUTE PROCEDURE uppercase_users_name()"
+    ensure
+      Fx.configuration.exclude_trigger_from_schema_condition = lambda { |trigger| false }
+    end
+  end
 end


### PR DESCRIPTION
In some cases it is necessary to prevent some functions or triggers from being included in schema.rb. 

An example of this is my use case, where I am using Timescale DB, which adds non-user defined triggers which bloat the schema when dumped. Additionally, my database is multitenant, meaning that the trigger is added once for every single tenant.

The addition of a configurable condition to control which functions and triggers make into the schema removes this issue.  