### PR TITLE
Fix #89 - Update use of PROCEDURE in specs and docs to match current Postgres use of FUNCTION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ addons:
   postgresql: "10"
   apt:
     packages:
-    - postgresql-10
-    - postgresql-client-10
+    - postgresql-14
+    - postgresql-client-14
 before_install:
   - "echo '--colour' > ~/.rspec"
   - "echo 'gem: --no-document' > ~/.gemrc"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In our example, this might look something like this:
 CREATE TRIGGER uppercase_users_name
     BEFORE INSERT ON users
     FOR EACH ROW
-    EXECUTE PROCEDURE uppercase_users_name();
+    EXECUTE FUNCTION uppercase_users_name();
 ```
 
 The generated migrations contains `create_function` and `create_trigger`

--- a/lib/fx/statements/trigger.rb
+++ b/lib/fx/statements/trigger.rb
@@ -24,7 +24,7 @@ module Fx
       #     CREATE TRIGGER uppercase_users_name
       #         BEFORE INSERT ON users
       #         FOR EACH ROW
-      #         EXECUTE PROCEDURE uppercase_users_name();
+      #         EXECUTE FUNCTION uppercase_users_name();
       #    SQL
       #
       def create_trigger(name, options = {})
@@ -101,7 +101,7 @@ module Fx
       #     CREATE TRIGGER uppercase_users_name
       #         BEFORE INSERT ON users
       #         FOR EACH ROW
-      #         EXECUTE PROCEDURE uppercase_users_name();
+      #         EXECUTE FUNCTION uppercase_users_name();
       #    SQL
       #
       def update_trigger(name, options = {})

--- a/spec/acceptance/user_manages_triggers_spec.rb
+++ b/spec/acceptance/user_manages_triggers_spec.rb
@@ -18,7 +18,7 @@ describe "User manages triggers" do
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
-          EXECUTE PROCEDURE uppercase_users_name();
+          EXECUTE FUNCTION uppercase_users_name();
     EOS
     successfully "rake db:migrate"
 
@@ -36,7 +36,7 @@ describe "User manages triggers" do
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users
           FOR EACH ROW
-          EXECUTE PROCEDURE uppercase_users_name();
+          EXECUTE FUNCTION uppercase_users_name();
     EOS
     successfully "rake db:migrate"
     execute <<-EOS

--- a/spec/features/triggers/migrations_spec.rb
+++ b/spec/features/triggers/migrations_spec.rb
@@ -22,7 +22,7 @@ describe "Trigger migrations", :db do
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
-          EXECUTE PROCEDURE uppercase_users_name();
+          EXECUTE FUNCTION uppercase_users_name();
     EOS
     with_trigger_definition(
       name: :uppercase_users_name,

--- a/spec/features/triggers/revert_spec.rb
+++ b/spec/features/triggers/revert_spec.rb
@@ -22,7 +22,7 @@ describe "Reverting migrations", :db do
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
-          EXECUTE PROCEDURE uppercase_users_name();
+          EXECUTE FUNCTION uppercase_users_name();
     EOS
     with_trigger_definition(
       name: :uppercase_users_name,
@@ -71,7 +71,7 @@ describe "Reverting migrations", :db do
       CREATE TRIGGER uppercase_users_name
           BEFORE UPDATE ON users
           FOR EACH ROW
-          EXECUTE PROCEDURE uppercase_users_name();
+          EXECUTE FUNCTION uppercase_users_name();
     EOS
     with_trigger_definition(
       name: :uppercase_users_name,

--- a/spec/fx/adapters/postgres/triggers_spec.rb
+++ b/spec/fx/adapters/postgres/triggers_spec.rb
@@ -26,7 +26,7 @@ module Fx
             CREATE TRIGGER uppercase_users_name
                 BEFORE INSERT ON users
                 FOR EACH ROW
-                EXECUTE PROCEDURE uppercase_users_name();
+                EXECUTE FUNCTION uppercase_users_name();
           EOS
 
           triggers = Postgres::Triggers.new(connection).all
@@ -37,7 +37,7 @@ module Fx
           expect(first.definition).to include("BEFORE INSERT")
           expect(first.definition).to match(/ON [public\.users|users]/)
           expect(first.definition).to include("FOR EACH ROW")
-          expect(first.definition).to include("EXECUTE PROCEDURE uppercase_users_name()")
+          expect(first.definition).to include("EXECUTE FUNCTION uppercase_users_name()")
         end
       end
     end

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -44,7 +44,7 @@ module Fx::Adapters
             CREATE TRIGGER uppercase_users_name
                 BEFORE INSERT ON users
                 FOR EACH ROW
-                EXECUTE PROCEDURE uppercase_users_name();
+                EXECUTE FUNCTION uppercase_users_name();
           EOS
         )
 
@@ -135,7 +135,7 @@ module Fx::Adapters
           CREATE TRIGGER uppercase_users_name
               BEFORE INSERT ON users
               FOR EACH ROW
-              EXECUTE PROCEDURE uppercase_users_name()
+              EXECUTE FUNCTION uppercase_users_name()
         EOS
         adapter.create_trigger(sql_definition)
 

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -59,7 +59,7 @@ describe Fx::Definition do
           CREATE TRIGGER check_update
           BEFORE UPDATE ON accounts
           FOR EACH ROW
-          EXECUTE PROCEDURE check_account_update();
+          EXECUTE FUNCTION check_account_update();
         EOS
         allow(File).to receive(:read).and_return(sql_definition)
 

--- a/spec/fx/schema_dumper/trigger_spec.rb
+++ b/spec/fx/schema_dumper/trigger_spec.rb
@@ -22,7 +22,7 @@ describe Fx::SchemaDumper::Trigger, :db do
       CREATE TRIGGER uppercase_users_name
           BEFORE INSERT ON users
           FOR EACH ROW
-          EXECUTE PROCEDURE uppercase_users_name();
+          EXECUTE FUNCTION uppercase_users_name();
     EOS
     connection.create_trigger(
       :uppercase_users_name,
@@ -35,6 +35,6 @@ describe Fx::SchemaDumper::Trigger, :db do
     output = stream.string
     expect(output).to include "create_trigger :uppercase_users_name"
     expect(output).to include "sql_definition: <<-SQL"
-    expect(output).to include "EXECUTE PROCEDURE uppercase_users_name()"
+    expect(output).to include "EXECUTE FUNCTION uppercase_users_name()"
   end
 end


### PR DESCRIPTION
This commit changes the use of PROCEDURE to FUNCTION to be consistent with the behavior of recent (11+) major versions of Postgres.  This allows specs to pass with these database versions.

It also updates `.travis.yml` to use Postgres 14.