### PR TITLE
Add dumping at beginning/end of schema

### DIFF
--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -39,10 +39,14 @@ module Fx
     # Defaults to false
     # @return Boolean
     attr_accessor :dump_functions_at_beginning_of_schema
+    attr_accessor :functions_to_dump_at_beginning_of_schema
+    attr_accessor :functions_to_dump_at_end_of_schema
 
     def initialize
       @database = Fx::Adapters::Postgres.new
       @dump_functions_at_beginning_of_schema = false
+      @functions_to_dump_at_beginning_of_schema = []
+      @functions_to_dump_at_end_of_schema = []
     end
   end
 end

--- a/lib/fx/schema_dumper/function.rb
+++ b/lib/fx/schema_dumper/function.rb
@@ -5,30 +5,48 @@ module Fx
     # @api private
     module Function
       def tables(stream)
+        dump_functions(stream, dumpable_functions_at_beginning)
+
         if Fx.configuration.dump_functions_at_beginning_of_schema
-          functions(stream)
-          empty_line(stream)
+          dump_functions(stream, dumpable_functions_excluded)
         end
 
         super
 
         unless Fx.configuration.dump_functions_at_beginning_of_schema
-          functions(stream)
-          empty_line(stream)
+          dump_functions(stream, dumpable_functions_excluded)
         end
+
+        dump_functions(stream, dumpable_functions_at_end)
       end
 
-      def empty_line(stream)
-        stream.puts if dumpable_functions_in_database.any?
-      end
-
-      def functions(stream)
-        dumpable_functions_in_database.each do |function|
+      def dump_functions(stream, functions)
+        functions.each do |function|
           stream.puts(function.to_schema)
         end
+
+        stream.puts if functions.any?
       end
 
       private
+
+      def dumpable_functions_at_beginning
+        @_dumpable_functions_at_beginning ||= dumpable_functions_in_database.select do |function|
+          function.name.in? Fx.configuration.functions_to_dump_at_beginning_of_schema
+        end
+      end
+
+      def dumpable_functions_at_end
+        @_dumpable_functions_at_end ||= dumpable_functions_in_database.select do |function|
+          function.name.in? Fx.configuration.functions_to_dump_at_end_of_schema
+        end
+      end
+
+      def dumpable_functions_excluded
+        @_dumpable_functions_excluded ||= dumpable_functions_in_database.reject do |func|
+          func.name.in? (Fx.configuration.functions_to_dump_at_beginning_of_schema | Fx.configuration.functions_to_dump_at_end_of_schema)
+        end
+      end
 
       def dumpable_functions_in_database
         @_dumpable_functions_in_database ||= Fx.database.functions


### PR DESCRIPTION
We needed a more flexible way to order the schema because we had different types of dependencies (veiws depend on functions, functions depend on views and so on), and the simple approach of dump on top or at the bottom just didn't work for us. This is what we came up with we've been using it for a couple of months now. 

Before committing to writing specs and cleaning it up, what do you folks think about it? Is this a feature you would like to add to fx?