### PR TITLE
Fix forward references when loading schema

### DIFF
--- a/lib/fx/schema_dumper/function.rb
+++ b/lib/fx/schema_dumper/function.rb
@@ -23,9 +23,11 @@ module Fx
       end
 
       def functions(stream)
+        stream.puts('  execute "SET check_function_bodies=off"')
         dumpable_functions_in_database.each do |function|
           stream.puts(function.to_schema)
         end
+        stream.puts('  execute "SET check_function_bodies=on"')
       end
 
       private


### PR DESCRIPTION
If your functions depend on each other, you may wind up with forward
references in your `schema.rb` file (even though we order them by oid,
e.g. if an older function was refactored to call new functions).
Postgres has the same problem in `pg_dump`, and they solve it by
temporarily disabling a GUC called `check_function_bodies`. This commit
adds calls to `schema.rb` to do the same thing.

I haven't added any new tests yet (though old ones all pass), and I haven't thought about how this breaks non-Postgres adapters (if there are any out there). So this is just a quick fix I can use personally, but if you would like a more polished version please let me know if you agree with the general approach here.