### PR TITLE
Add ERB Support for SQL definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/spec/dummy

--- a/lib/fx/definition.rb
+++ b/lib/fx/definition.rb
@@ -8,7 +8,7 @@ module Fx
     end
 
     def to_sql
-      File.read(find_file || full_path).tap do |content|
+      ERB.new(File.read(find_file || full_path)).result.tap do |content|
         if content.empty?
           raise "Define #{@type} in #{path} before migrating."
         end

--- a/lib/fx/definition.rb
+++ b/lib/fx/definition.rb
@@ -3,7 +3,7 @@ module Fx
   class Definition
     def initialize(name:, version:, type: "function")
       @name = name
-      @version = version.to_i
+      @version = version
       @type = type
     end
 
@@ -24,7 +24,8 @@ module Fx
     end
 
     def version
-      @version.to_s.rjust(2, "0")
+      @version = latest_version if @version == :latest
+      @version.to_i.to_s.rjust(2, "0")
     end
 
     private
@@ -41,6 +42,11 @@ module Fx
 
     def migration_paths
       Rails.application.config.paths["db/migrate"].expanded
+    end
+
+    def latest_version
+      Dir.glob(Rails.root.join("db", @type.pluralize, "#{@name}*.sql")).max =~ /#{@name}_v(\d*).sql/i
+      $1
     end
   end
 end

--- a/lib/fx/version.rb
+++ b/lib/fx/version.rb
@@ -1,4 +1,4 @@
 module Fx
   # @api private
-  VERSION = "0.7.0"
+  VERSION = "1.7.1"
 end

--- a/lib/fx/version.rb
+++ b/lib/fx/version.rb
@@ -1,4 +1,4 @@
 module Fx
   # @api private
-  VERSION = "1.7.1"
+  VERSION = "1.7.2"
 end

--- a/lib/fx/version.rb
+++ b/lib/fx/version.rb
@@ -1,4 +1,4 @@
 module Fx
   # @api private
-  VERSION = "1.7.2"
+  VERSION = "0.7.0"
 end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -25,7 +25,7 @@ describe Fx::Definition do
 
         expect { definition.to_sql }.to raise_error(
           RuntimeError,
-          %r(Define function in db/functions/test_v01.sql before migrating),
+          %r{Define function in db/functions/test_v01.sql before migrating}
         )
       end
 
@@ -99,7 +99,7 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "trigger",
+          type: "trigger"
         )
 
         expect(definition.to_sql).to eq sql_definition
@@ -110,12 +110,12 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "trigger",
+          type: "trigger"
         )
 
         expect { definition.to_sql }.to raise_error(
           RuntimeError,
-          %r(Define trigger in db/triggers/test_v01.sql before migrating),
+          %r{Define trigger in db/triggers/test_v01.sql before migrating}
         )
       end
     end
@@ -135,7 +135,7 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "trigger",
+          type: "trigger"
         )
 
         expect(definition.path).to eq "db/triggers/test_v01.sql"

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "acceptance_helper"
 
 describe Fx::Definition do
   describe "#to_sql" do
@@ -41,7 +42,7 @@ describe Fx::Definition do
           <% end %>
         EOS
 
-        erb_sql_definition = (<<-EOS).delete("\n").squeeze(' ').strip
+        erb_sql_definition = <<-EOS.delete("\n").squeeze(" ").strip
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
@@ -59,7 +60,7 @@ describe Fx::Definition do
 
         definition = Fx::Definition.new(name: "test", version: 1)
 
-        expect(definition.to_sql.delete("\n").squeeze(' ').strip).to eq erb_sql_definition
+        expect(definition.to_sql.delete("\n").squeeze(" ").strip).to eq erb_sql_definition
       end
 
       context "when definition is at Rails engine" do
@@ -162,6 +163,17 @@ describe Fx::Definition do
       definition = Fx::Definition.new(name: :_, version: 15)
 
       expect(definition.version).to eq "15"
+    end
+
+    it "returns latest version" do
+      successfully "rails generate fx:function adder"
+      write_function_definition "adder_v01", "select 1;"
+      successfully "rails generate fx:function adder"
+      write_function_definition "adder_v02", "select 5;"
+
+      definition = Fx::Definition.new(name: :adder, version: :latest)
+
+      expect(definition.version).to eq "02"
     end
   end
 end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -41,7 +41,7 @@ describe Fx::Definition do
           <% end %>
         EOS
 
-        erb_sql_definition = (<<-EOS).delete("\n").squeeze(' ').strip
+        erb_sql_definition = <<-EOS.delete("\n").squeeze(" ").strip
           CREATE OR REPLACE FUNCTION test()
           RETURNS text AS $$
           BEGIN
@@ -59,7 +59,7 @@ describe Fx::Definition do
 
         definition = Fx::Definition.new(name: "test", version: 1)
 
-        expect(definition.to_sql.delete("\n").squeeze(' ').strip).to eq erb_sql_definition
+        expect(definition.to_sql.delete("\n").squeeze(" ").strip).to eq erb_sql_definition
       end
 
       context "when definition is at Rails engine" do

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "acceptance_helper"
 
 describe Fx::Definition do
   describe "#to_sql" do
@@ -9,7 +8,7 @@ describe Fx::Definition do
           CREATE OR REPLACE FUNCTION test()
           RETURNS text AS $$
           BEGIN
-              RETURN 'test';
+            RETURN 'test';
           END;
           $$ LANGUAGE plpgsql;
         EOS
@@ -26,7 +25,7 @@ describe Fx::Definition do
 
         expect { definition.to_sql }.to raise_error(
           RuntimeError,
-          %r{Define function in db/functions/test_v01.sql before migrating}
+          %r(Define function in db/functions/test_v01.sql before migrating),
         )
       end
 
@@ -36,31 +35,31 @@ describe Fx::Definition do
             CREATE OR REPLACE FUNCTION <%= function %>()
             RETURNS text AS $$
             BEGIN
-                RETURN '<%= function %>';
+              RETURN '<%= function %>';
             END;
             $$ LANGUAGE plpgsql;
           <% end %>
         EOS
 
-        erb_sql_definition = <<-EOS.delete("\n").squeeze(" ").strip
-            CREATE OR REPLACE FUNCTION test()
-            RETURNS text AS $$
-            BEGIN
-                RETURN 'test';
-            END;
-            $$ LANGUAGE plpgsql;
-            CREATE OR REPLACE FUNCTION west()
-            RETURNS text AS $$
-            BEGIN
-                RETURN 'west';
-            END;
-            $$ LANGUAGE plpgsql;
+        erb_sql_definition = (<<-EOS).delete("\n").squeeze(' ').strip
+          CREATE OR REPLACE FUNCTION test()
+          RETURNS text AS $$
+          BEGIN
+            RETURN 'test';
+          END;
+          $$ LANGUAGE plpgsql;
+          CREATE OR REPLACE FUNCTION west()
+          RETURNS text AS $$
+          BEGIN
+            RETURN 'west';
+          END;
+          $$ LANGUAGE plpgsql;
         EOS
         allow(File).to receive(:read).and_return(sql_definition)
 
         definition = Fx::Definition.new(name: "test", version: 1)
 
-        expect(definition.to_sql.delete("\n").squeeze(" ").strip).to eq erb_sql_definition
+        expect(definition.to_sql.delete("\n").squeeze(' ').strip).to eq erb_sql_definition
       end
 
       context "when definition is at Rails engine" do
@@ -69,7 +68,7 @@ describe Fx::Definition do
             CREATE OR REPLACE FUNCTION test()
             RETURNS text AS $$
             BEGIN
-                RETURN 'test';
+              RETURN 'test';
             END;
             $$ LANGUAGE plpgsql;
           EOS
@@ -100,7 +99,7 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "trigger"
+          type: "trigger",
         )
 
         expect(definition.to_sql).to eq sql_definition
@@ -111,12 +110,12 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "trigger"
+          type: "trigger",
         )
 
         expect { definition.to_sql }.to raise_error(
           RuntimeError,
-          %r{Define trigger in db/triggers/test_v01.sql before migrating}
+          %r(Define trigger in db/triggers/test_v01.sql before migrating),
         )
       end
     end
@@ -136,7 +135,7 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "trigger"
+          type: "trigger",
         )
 
         expect(definition.path).to eq "db/triggers/test_v01.sql"
@@ -163,17 +162,6 @@ describe Fx::Definition do
       definition = Fx::Definition.new(name: :_, version: 15)
 
       expect(definition.version).to eq "15"
-    end
-
-    it "returns latest version" do
-      successfully "rails generate fx:function adder"
-      write_function_definition "adder_v01", "select 1;"
-      successfully "rails generate fx:function adder"
-      write_function_definition "adder_v02", "select 5;"
-
-      definition = Fx::Definition.new(name: :adder, version: :latest)
-
-      expect(definition.version).to eq "02"
     end
   end
 end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -57,7 +57,7 @@ describe Fx::Definition do
         EOS
         allow(File).to receive(:read).and_return(sql_definition)
 
-        definition = Fx::Definition.new(name: "test", version: 1)
+        definition = Fx::Definition.function(name: "test", version: 1)
 
         expect(definition.to_sql.delete("\n").squeeze(" ").strip).to eq erb_sql_definition
       end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -40,7 +40,6 @@ describe Fx::Definition do
             $$ LANGUAGE plpgsql;
           <% end %>
         EOS
-
         erb_sql_definition = <<-EOS.delete("\n").squeeze(" ").strip
           CREATE OR REPLACE FUNCTION test()
           RETURNS text AS $$

--- a/spec/fx/function_spec.rb
+++ b/spec/fx/function_spec.rb
@@ -44,7 +44,7 @@ module Fx
           "definition" => "CREATE OR REPLACE TRIGGER uppercase_users_name ..."
         )
 
-        expect(function.to_schema).to eq <<-'EOS'
+        expect(function.to_schema).to eq <<-EOS
   create_function :uppercase_users_name, sql_definition: <<-'SQL'
       CREATE OR REPLACE TRIGGER uppercase_users_name ...
   SQL


### PR DESCRIPTION
Allow for ERB interpolation in SQL definition files.  This is helpful when SQL definition relies on some ruby constants or methods.
