### PR TITLE
Fix generating function migrations for functions in custom schemas

### DIFF
--- a/lib/fx/definition.rb
+++ b/lib/fx/definition.rb
@@ -41,7 +41,7 @@ module Fx
     private
 
     def filename
-      @_filename ||= "#{@name}_v#{version}.sql"
+      @_filename ||= "#{@name.to_s.tr(".", "_")}_v#{version}.sql"
     end
 
     def find_file

--- a/lib/generators/fx/function/function_generator.rb
+++ b/lib/generators/fx/function/function_generator.rb
@@ -54,6 +54,15 @@ module Fx
           @_version ||= previous_version.next
         end
 
+        alias_method :original_file_name, :file_name
+        def file_name
+          super.tr(".", "_")
+        end
+
+        def singular_name
+          original_file_name
+        end
+
         def migration_class_name
           if updating_existing_function?
             "UpdateFunction#{class_name}ToVersion#{version}"

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -87,6 +87,12 @@ describe Fx::Definition do
 
         expect(definition.path).to eq "db/functions/test_v01.sql"
       end
+
+      it "uses underscores for schema-specified names" do
+        definition = Fx::Definition.new(name: "foo.test", version: 15)
+
+        expect(definition.path).to eq "db/functions/foo_test_v15.sql"
+      end
     end
 
     context "representing a trigger definition" do

--- a/spec/generators/fx/trigger/trigger_generator_spec.rb
+++ b/spec/generators/fx/trigger/trigger_generator_spec.rb
@@ -56,4 +56,29 @@ describe Fx::Generators::TriggerGenerator, :generator do
     expect(migration_file(migration)).to contain "UpdateTriggerTestToVersion2"
     expect(migration_file(migration)).to contain "on: :some_table"
   end
+
+  it "creates a trigger on a schema-specified table" do
+    migration = file("db/migrate/create_trigger_test.rb")
+    trigger_definition = file("db/triggers/test_v01.sql")
+
+    run_generator ["test", "table_name" => "foo.some_table"]
+
+    expect(trigger_definition).to exist
+    expect(migration).to be_a_migration
+    expect(migration_file(migration)).to contain "CreateTriggerTest"
+    expect(migration_file(migration)).to contain 'on: "foo.some_table"'
+  end
+
+  it "updates an existing trigger on a schema-specified table" do
+    allow(Dir).to receive(:entries).and_return(["test_v01.sql"])
+    migration = file("db/migrate/update_trigger_test_to_version_2.rb")
+    trigger_definition = file("db/triggers/test_v02.sql")
+
+    run_generator ["test", "table_name" => "foo.some_table"]
+
+    expect(trigger_definition).to exist
+    expect(migration).to be_a_migration
+    expect(migration_file(migration)).to contain "UpdateTriggerTestToVersion2"
+    expect(migration_file(migration)).to contain 'on: "foo.some_table"'
+  end
 end


### PR DESCRIPTION
Currently things don't quite work right if you try to generate a function migration for a function inside a custom PostgreSQL schema. The underlying `create_function` (and other methods) work with a schema-specified name, however the migration file names and file naming assumptions get confused when a schema name is in the mix.

For example, if you currently run a command like this:

```
rails generate fx:function my_schema.my_function
```

You'll end up with `db/functions/my_schema.my_function_v01.sql` and `db/migrate/[timestamp]_create_function_my_schema.my_function.rb` files. The extra dot in the migration filename causes issues for Rails, as does the invalid class name it uses inside (`class CreateFunctionMySchema.myFunction < ActiveRecord::Migration[7.0]`).

This fixes the issue by replacing dots in the file name/table name with underscores, which allows for the normal Rails filename and class name conventions to work. But the original name, with the dot, is still retained and used inside the migration itself for the `create_function` method call, so the underlying SQL for creating and rolling back functions is correctly schema-specified.

This adds test coverage for this function generator handling schema-specified table names. It also adds test coverage for schema-specified table names being used with the trigger generator, but that all worked already since for triggers the table name wasn't present in the file name, so this wasn't an issue.