### PR TITLE
Add support for SQL views and materialized views

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@
 [![Documentation Quality](http://inch-ci.org/github/teoljungberg/fx.svg?branch=master)](http://inch-ci.org/github/teoljungberg/fx)
 
 F(x) adds methods to `ActiveRecord::Migration` to create and manage database
-functions and triggers in Rails.
+functions, triggers and views in Rails.
 
-Using F(x), you can bring the power of SQL functions and triggers to your Rails
-application without having to switch your schema format to SQL. F(x) provides
-a convention for versioning functions and triggers that keeps your migration
-history consistent and reversible and avoids having to duplicate SQL strings
-across migrations. As an added bonus, you define the structure of your function
-in a SQL file, meaning you get full SQL syntax highlighting in the editor of
-your choice and can easily test your SQL in the database console during
-development.
+Using F(x), you can bring the power of SQL functions, triggers and views to your
+Rails application without having to switch your schema format to SQL. F(x)
+provides a convention for versioning functions, triggers and views that keeps
+your migration history consistent and reversible and avoids having to duplicate
+SQL strings across migrations. As an added bonus, you define the structure of
+your function, trigger and view in a SQL file, meaning you get full SQL syntax
+highlighting in the editor of your choice and can easily test your SQL in the
+database console during development.
 
 F(x) ships with support for PostgreSQL. The adapter is configurable (see
 `Fx::Configuration`) and has a minimal interface (see
 `Fx::Adapters::Postgres`) that other gems can provide.
 
-## Great, how do I create a trigger and a function?
+## Great, how do I create a trigger, a view and a function?
 
 You've got this great idea for a function you'd like to call
 `uppercase_users_name`. You can create the migration and the corresponding
@@ -52,15 +52,30 @@ CREATE TRIGGER uppercase_users_name
     EXECUTE FUNCTION uppercase_users_name();
 ```
 
-The generated migrations contains `create_function` and `create_trigger`
-statements. The migration is reversible and the schema will be dumped into your
-`schema.rb` file.
+Next, let's add a view called `active_users`.
+
+```sh
+% rails generate fx:view active_users
+      create  db/views/active_users_v01.sql
+      create  db/migrate/[TIMESTAMP]_create_view_active_users.rb
+```
+
+In our example, this might look something like this:
+
+```sql
+CREATE VIEW active_users AS
+    SELECT * FROM users WHERE active = true;
+```
+
+The generated migrations contains `create_function`, `create_trigger` and
+`create_view` statements. The migration is reversible and the schema will be
+dumped into your `schema.rb` file.
 
 ```sh
 % rake db:migrate
 ```
 
-## Cool, but what if I need to change a trigger or function?
+## Cool, but what if I need to change a trigger, view or function?
 
 Here's where F(x) really shines. Run that same function generator once more:
 
@@ -75,9 +90,9 @@ version 1, created a copy of that definition as version 2, and created a
 migration to update to the version 2 schema. All that's left for you to do is
 tweak the schema in the new definition and run the `update_function` migration.
 
-## I don't need this trigger or function anymore. Make it go away.
+## I don't need this trigger, view or function anymore. Make it go away.
 
-F(x) gives you `drop_trigger` and `drop_function` too:
+F(x) gives you `drop_trigger`, `drop_function` and `drop_view` too:
 
 ```ruby
 def change

--- a/lib/fx.rb
+++ b/lib/fx.rb
@@ -7,6 +7,7 @@ require "fx/function"
 require "fx/statements"
 require "fx/schema_dumper"
 require "fx/trigger"
+require "fx/view"
 require "fx/railtie"
 
 # F(x) adds methods `ActiveRecord::Migration` to create and manage database

--- a/lib/fx/adapters/postgres/views.rb
+++ b/lib/fx/adapters/postgres/views.rb
@@ -1,0 +1,82 @@
+require "fx/view"
+
+module Fx
+  module Adapters
+    class Postgres
+      # Fetches defined views from the postgres connection.
+      # @api private
+      class Views
+        # The SQL query used by F(x) to retrieve the views considered
+        # dumpable into `db/schema.rb`.
+        VIEWS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
+          SELECT
+            viewname AS name,
+            definition,
+            false AS materialized
+          FROM pg_catalog.pg_views
+          WHERE schemaname = 'public' AND viewowner = CURRENT_USER;
+        EOS
+
+        MATERIALIZED_VIEWS_WITH_DEFINITIONS_QUERY = <<-EOS.freeze
+          SELECT
+              name,
+              CASE
+                WHEN index_definition IS NULL THEN definition
+                ELSE definition || E'\n\n' || index_definition
+              END AS definition,
+              true AS materialized
+            FROM (SELECT
+              matviewname AS name,
+              definition,
+              STRING_AGG(pg_indexes.indexdef || ';', E'\n') AS index_definition
+            FROM pg_catalog.pg_matviews
+            LEFT JOIN pg_indexes ON pg_indexes.tablename = pg_matviews.matviewname
+            WHERE pg_matviews.schemaname = 'public' AND pg_matviews.matviewowner = CURRENT_USER
+            GROUP BY pg_matviews.matviewname, pg_matviews.definition) materialized_views;
+        EOS
+
+        # Wraps #all as a static facade.
+        #
+        # @return [Array<Fx::View>]
+        def self.all(*args)
+          new(*args).all
+        end
+
+        def initialize(connection)
+          @connection = connection
+        end
+
+        # All of the views that this connection has defined.
+        #
+        # @return [Array<Fx::View>]
+        def all
+          all_views.concat(all_materialized_views)
+        end
+
+        private
+
+        attr_reader :connection
+
+        def all_views
+          views_from_postgres.map { |view| to_fx_view(view) }
+        end
+
+        def all_materialized_views
+          materialized_views_from_postgres.map { |view| to_fx_view(view) }
+        end
+
+        def views_from_postgres
+          connection.execute(VIEWS_WITH_DEFINITIONS_QUERY)
+        end
+
+        def materialized_views_from_postgres
+          connection.execute(MATERIALIZED_VIEWS_WITH_DEFINITIONS_QUERY)
+        end
+
+        def to_fx_view(result)
+          Fx::View.new(result)
+        end
+      end
+    end
+  end
+end

--- a/lib/fx/command_recorder.rb
+++ b/lib/fx/command_recorder.rb
@@ -1,12 +1,14 @@
 require "fx/command_recorder/arguments"
 require "fx/command_recorder/function"
 require "fx/command_recorder/trigger"
+require "fx/command_recorder/view"
 
 module Fx
   # @api private
   module CommandRecorder
     include Function
     include Trigger
+    include View
 
     private
 

--- a/lib/fx/command_recorder/view.rb
+++ b/lib/fx/command_recorder/view.rb
@@ -1,0 +1,30 @@
+module Fx
+  module CommandRecorder
+    # @api private
+    module View
+      def create_view(*args)
+        record(:create_view, args)
+      end
+
+      def drop_view(*args)
+        record(:drop_view, args)
+      end
+
+      def update_view(*args)
+        record(:update_view, args)
+      end
+
+      def invert_create_view(args)
+        [:drop_view, args]
+      end
+
+      def invert_drop_view(args)
+        perform_inversion(:create_view, args)
+      end
+
+      def invert_update_view(args)
+        perform_inversion(:update_view, args)
+      end
+    end
+  end
+end

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -1,10 +1,12 @@
 require "fx/schema_dumper/function"
 require "fx/schema_dumper/trigger"
+require "fx/schema_dumper/view"
 
 module Fx
   # @api private
   module SchemaDumper
     include Function
     include Trigger
+    include View
   end
 end

--- a/lib/fx/schema_dumper/view.rb
+++ b/lib/fx/schema_dumper/view.rb
@@ -1,0 +1,30 @@
+require "rails"
+
+module Fx
+  module SchemaDumper
+    # @api private
+    module View
+      def tables(stream)
+        super
+        views(stream)
+        empty_line(stream)
+      end
+
+      def empty_line(stream)
+        stream.puts if dumpable_view_in_database.any?
+      end
+
+      def views(stream)
+        dumpable_view_in_database.each do |view|
+          stream.puts(view.to_schema)
+        end
+      end
+
+      private
+
+      def dumpable_view_in_database
+        @_dumpable_view_in_database ||= Fx.database.views
+      end
+    end
+  end
+end

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -1,11 +1,13 @@
 require "rails"
 require "fx/statements/function"
 require "fx/statements/trigger"
+require "fx/statements/view"
 
 module Fx
   # @api private
   module Statements
     include Function
     include Trigger
+    include View
   end
 end

--- a/lib/fx/statements/view.rb
+++ b/lib/fx/statements/view.rb
@@ -31,7 +31,7 @@ module Fx
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,
-            "version or sql_definition must be specified",
+            "version or sql_definition must be specified"
           )
         end
         sql_definition = sql_definition.strip_heredoc if sql_definition
@@ -90,7 +90,7 @@ module Fx
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,
-            "version or sql_definition must be specified",
+            "version or sql_definition must be specified"
           )
         end
 

--- a/lib/fx/statements/view.rb
+++ b/lib/fx/statements/view.rb
@@ -27,7 +27,10 @@ module Fx
       #     SELECT * users WHERE active = true;
       #   SQL
       #
-      def create_view(name, version: 1, sql_definition: nil, materialized: false)
+      def create_view(name, options = {})
+        version = options.fetch(:version, 1)
+        sql_definition = options[:sql_definition]
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,
@@ -56,7 +59,9 @@ module Fx
       # @example Drop a view, rolling back to version 2 on rollback
       #   drop_view(:active_users, revert_to_version: 2)
       #
-      def drop_view(name, revert_to_version: nil, materialized: false)
+      def drop_view(name, options = {})
+        materialized = options.fetch(:materialized, false)
+
         Fx.database.drop_view(name, materialized: materialized)
       end
 
@@ -86,7 +91,11 @@ module Fx
       #     SELECT * users WHERE active = true;
       #   SQL
       #
-      def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+      def update_view(name, options = {})
+        version = options.fetch(:version, 1)
+        sql_definition = options[:sql_definition]
+        materialized = options.fetch(:materialized, false)
+
         if version.nil? && sql_definition.nil?
           raise(
             ArgumentError,

--- a/lib/fx/statements/view.rb
+++ b/lib/fx/statements/view.rb
@@ -1,0 +1,108 @@
+require "rails"
+
+module Fx
+  module Statements
+    # Methods that are made available in migrations for managing Fx views.
+    module View
+      # @api private
+      DEFINTION_TYPE = "view".freeze
+
+      # Create a new database view.
+      #
+      # @param name [String, Symbol] The name of the database view.
+      # @param version [Fixnum] The version number of the view, used to
+      #   find the definition file in `db/views`. This defaults to `1` if
+      #   not provided.
+      # @param sql_definition [String] The SQL query for the view schema.
+      #   If both `sql_defintion` and `version` are provided,
+      #   `sql_definition` takes prescedence.
+      # @return The database response from executing the create statement.
+      #
+      # @example Create from `db/views/active_users_v02.sql`
+      #   create_view(:active_users, version: 2)
+      #
+      # @example Create from provided SQL string
+      #   create_view(:active_users, sql_definition: <<-SQL)
+      #     CREATE VIEW active_users AS
+      #     SELECT * users WHERE active = true;
+      #   SQL
+      #
+      def create_view(name, version: 1, sql_definition: nil, materialized: false)
+        if version.nil? && sql_definition.nil?
+          raise(
+            ArgumentError,
+            "version or sql_definition must be specified",
+          )
+        end
+        sql_definition = sql_definition.strip_heredoc if sql_definition
+        sql_definition ||= Fx::Definition.new(
+          name: name,
+          version: version,
+          type: DEFINTION_TYPE
+        ).to_sql
+
+        Fx.database.create_view(sql_definition)
+      end
+
+      # Drop a database view by name.
+      #
+      # @param name [String, Symbol] The name of the database view.
+      # @param revert_to_version [Fixnum] Used to reverse the `drop_view`
+      #   command on `rake db:rollback`. The provided version will be passed as
+      #   the `version` argument to {#create_view}.
+      # @param materialized [Boolean] defines if the view is materialized or not.
+      # @return The database response from executing the drop statement.
+      #
+      # @example Drop a view, rolling back to version 2 on rollback
+      #   drop_view(:active_users, revert_to_version: 2)
+      #
+      def drop_view(name, revert_to_version: nil, materialized: false)
+        Fx.database.drop_view(name, materialized: materialized)
+      end
+
+      # Update a database view.
+      #
+      # @param name [String, Symbol] The name of the database view.
+      # @param version [Fixnum] The version number of the view, used to
+      #   find the definition file in `db/views`. This defaults to `1` if
+      #   not provided.
+      # @param sql_definition [String] The SQL query for the view schema.
+      #   If both `sql_defintion` and `version` are provided,
+      #   `sql_definition` takes prescedence.
+      # @param materialized [Boolean] defines if the view is materialized or not.
+      # @return The database response from executing the create statement.
+      #
+      # @example Update view to a given version
+      #   update_view(
+      #     :active_users,
+      #     version: 3,
+      #     revert_to_version: 2,
+      #   )
+      #
+      # @example Update view from provided SQL string
+      #   update_view(:active_users, sql_definition: <<-SQL)
+      #     DROP VIEW IF EXISTS active_users;
+      #     CREATE VIEW active_users AS
+      #     SELECT * users WHERE active = true;
+      #   SQL
+      #
+      def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+        if version.nil? && sql_definition.nil?
+          raise(
+            ArgumentError,
+            "version or sql_definition must be specified",
+          )
+        end
+
+        sql_definition = sql_definition.strip_heredoc if sql_definition
+        sql_definition ||= Fx::Definition.new(
+          name: name,
+          version: version,
+          type: DEFINTION_TYPE
+        ).to_sql
+
+        Fx.database.update_view(name, sql_definition, materialized: materialized)
+      end
+    end
+  end
+end

--- a/lib/fx/view.rb
+++ b/lib/fx/view.rb
@@ -1,0 +1,41 @@
+module Fx
+  # @api private
+  class View
+    include Comparable
+
+    attr_reader :name, :definition, :materialized
+    delegate :<=>, to: :name
+
+    def initialize(view_row)
+      @name = view_row.fetch("name")
+      @materialized = view_row.fetch("materialized", false)
+      @definition = view_row.fetch("definition").strip
+    end
+
+    def ==(other)
+      name == other.name && definition == other.definition
+    end
+
+    def to_schema
+      <<-SCHEMA.indent(2)
+create_view :#{name}, sql_definition: <<-\SQL
+#{definition_with_create_statement.indent(4).rstrip}
+SQL
+      SCHEMA
+    end
+
+    private
+
+    def type
+      if materialized
+        "MATERIALIZED VIEW"
+      else
+        "VIEW"
+      end
+    end
+
+    def definition_with_create_statement
+      "CREATE #{type} #{name} AS\n#{definition}"
+    end
+  end
+end

--- a/lib/fx/view.rb
+++ b/lib/fx/view.rb
@@ -17,10 +17,10 @@ module Fx
     end
 
     def to_schema
-      <<-SCHEMA.indent(2)
-create_view :#{name}, sql_definition: <<-\SQL
-#{definition_with_create_statement.indent(4).rstrip}
-SQL
+      <<~SCHEMA.indent(2)
+        create_view :#{name}, sql_definition: <<-\SQL
+        #{definition_with_create_statement.indent(4).rstrip}
+        SQL
       SCHEMA
     end
 

--- a/lib/generators.rb
+++ b/lib/generators.rb
@@ -5,6 +5,7 @@ module Fx
   #
   # * {file:lib/generators/fx/function/USAGE Function Generator}
   # * {file:lib/generators/fx/trigger/USAGE Trigger Generator}
+  # * {file:lib/generators/fx/view/USAGE View Generator}
   # * {file:README.md README}
   module Generators
   end

--- a/lib/generators/fx/view/USAGE
+++ b/lib/generators/fx/view/USAGE
@@ -1,0 +1,12 @@
+Description:
+  Create a new database view for your application. This will create a new
+  function definition file and the accompanying migration.
+
+  When --materialized is passe, it generates a materialized view definition.
+  When --no-migration is passed, skips generating a migration.
+
+Examples:
+    rails generate fx:view test
+
+      create: db/views/test_v01.sql
+      create: db/migrate/[TIMESTAMP]_create_test.rb

--- a/lib/generators/fx/view/templates/db/migrate/create_view.erb
+++ b/lib/generators/fx/view/templates/db/migrate/create_view.erb
@@ -1,0 +1,5 @@
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
+  def change
+    create_view <%= formatted_name %><%= ', materialized: true' if materialized? %>
+  end
+end

--- a/lib/generators/fx/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/fx/view/templates/db/migrate/update_view.erb
@@ -1,0 +1,5 @@
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
+  def change
+    update_view <%= formatted_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
+  end
+end

--- a/lib/generators/fx/view/view_generator.rb
+++ b/lib/generators/fx/view/view_generator.rb
@@ -59,6 +59,15 @@ module Fx
           options[:materialized]
         end
 
+        alias_method :original_file_name, :file_name
+        def file_name
+          super.tr(".", "_")
+        end
+
+        def singular_name
+          original_file_name
+        end
+
         def migration_class_name
           if updating_existing_view?
             "UpdateView#{class_name}ToVersion#{version}"

--- a/lib/generators/fx/view/view_generator.rb
+++ b/lib/generators/fx/view/view_generator.rb
@@ -1,0 +1,133 @@
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Fx
+  module Generators
+    # @api private
+    class ViewGenerator < Rails::Generators::NamedBase
+      include Rails::Generators::Migration
+      source_root File.expand_path("../templates", __FILE__)
+
+      class_option :materialized, type: :boolean, default: false
+      class_option :migration, type: :boolean
+
+      def create_views_directory
+        unless view_definition_path.exist?
+          empty_directory(view_definition_path)
+        end
+      end
+
+      def create_view_definition
+        if creating_new_view?
+          create_file definition.path
+        else
+          copy_file previous_definition.full_path, definition.full_path
+        end
+      end
+
+      def create_migration_file
+        return if skip_migration_creation?
+        if updating_existing_view?
+          migration_template(
+            "db/migrate/update_view.erb",
+            "db/migrate/update_view_#{file_name}_to_version_#{version}.rb",
+          )
+        else
+          migration_template(
+            "db/migrate/create_view.erb",
+            "db/migrate/create_view_#{file_name}.rb",
+          )
+        end
+      end
+
+      def self.next_migration_number(dir)
+        ::ActiveRecord::Generators::Base.next_migration_number(dir)
+      end
+
+      no_tasks do
+        def previous_version
+          @_previous_version ||= Dir.entries(view_definition_path).
+            map { |name| version_regex.match(name).try(:[], "version").to_i }.
+            max
+        end
+
+        def version
+          @_version ||= previous_version.next
+        end
+
+        def materialized?
+          options[:materialized]
+        end
+
+        def migration_class_name
+          if updating_existing_view?
+            "UpdateView#{class_name}ToVersion#{version}"
+          else
+            super
+          end
+        end
+
+        def activerecord_migration_class
+          if ActiveRecord::Migration.respond_to?(:current_version)
+            "ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]"
+          else
+            "ActiveRecord::Migration"
+          end
+        end
+
+        def formatted_name
+          if singular_name.include?(".")
+            "\"#{singular_name}\""
+          else
+            ":#{singular_name}"
+          end
+        end
+      end
+
+      private
+
+      def view_definition_path
+        @_view_definition_path ||= Rails.root.join(*%w(db views))
+      end
+
+      def version_regex
+        /\A#{file_name}_v(?<version>\d+)\.sql\z/
+      end
+
+      def updating_existing_view?
+        previous_version > 0
+      end
+
+      def creating_new_view?
+        previous_version == 0
+      end
+
+      def definition
+        Fx::Definition.new(
+          name: file_name,
+          version: version,
+          type: "view"
+        )
+      end
+
+      def previous_definition
+        Fx::Definition.new(
+          name: file_name,
+          version: previous_version,
+          type: "view"
+        )
+      end
+
+      # Skip creating migration file if:
+      #   - migrations option is nil or false
+      def skip_migration_creation?
+        !migration
+      end
+
+      # True unless explicitly false
+      def migration
+        options[:migration] != false
+      end
+    end
+  end
+end

--- a/lib/generators/fx/view/view_generator.rb
+++ b/lib/generators/fx/view/view_generator.rb
@@ -30,12 +30,12 @@ module Fx
         if updating_existing_view?
           migration_template(
             "db/migrate/update_view.erb",
-            "db/migrate/update_view_#{file_name}_to_version_#{version}.rb",
+            "db/migrate/update_view_#{file_name}_to_version_#{version}.rb"
           )
         else
           migration_template(
             "db/migrate/create_view.erb",
-            "db/migrate/create_view_#{file_name}.rb",
+            "db/migrate/create_view_#{file_name}.rb"
           )
         end
       end
@@ -46,9 +46,9 @@ module Fx
 
       no_tasks do
         def previous_version
-          @_previous_version ||= Dir.entries(view_definition_path).
-            map { |name| version_regex.match(name).try(:[], "version").to_i }.
-            max
+          @_previous_version ||= Dir.entries(view_definition_path)
+            .map { |name| version_regex.match(name).try(:[], "version").to_i }
+            .max
         end
 
         def version
@@ -96,7 +96,7 @@ module Fx
       private
 
       def view_definition_path
-        @_view_definition_path ||= Rails.root.join(*%w(db views))
+        @_view_definition_path ||= Rails.root.join(*%w[db views])
       end
 
       def version_regex

--- a/spec/acceptance/user_manages_views_spec.rb
+++ b/spec/acceptance/user_manages_views_spec.rb
@@ -1,0 +1,23 @@
+require "acceptance_helper"
+
+describe "User manages views" do
+  it "handles simple views" do
+    successfully "rails generate model employee name:string active:boolean"
+    successfully "rails generate fx:view active_employees"
+    write_view_definition "active_employees_v01", <<-EOS
+      CREATE VIEW active_employees AS
+          SELECT * FROM employees WHERE active = true;
+    EOS
+    successfully "rake db:migrate"
+
+    execute <<-EOS
+      INSERT INTO employees
+      (name, created_at, updated_at, active)
+      VALUES
+      ('Bob', NOW(), NOW(), true),
+      ('John', NOW(), NOW(), false);
+    EOS
+    result = execute("SELECT name FROM active_employees;")
+    expect(result).to eq("name" => "Bob")
+  end
+end

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -47,6 +47,10 @@ RSpec.configure do |config|
     write_definition(file, contents, "triggers")
   end
 
+  def write_view_definition(file, contents)
+    write_definition(file, contents, "views")
+  end
+
   def write_definition(file, contents, directory)
     File.open("db/#{directory}/#{file}.sql", File::WRONLY) do |definition|
       definition.truncate(0)

--- a/spec/features/views/migrations_spec.rb
+++ b/spec/features/views/migrations_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe "View migrations", :db do
+  around do |example|
+    connection.execute <<-EOS
+      CREATE TABLE users (
+          id int PRIMARY KEY,
+          name varchar(256),
+          upper_name varchar(256),
+          active boolean
+      );
+    EOS
+    sql_definition = <<-EOS
+      CREATE VIEW active_users AS
+          SELECT * FROM users WHERE active = true;
+    EOS
+    with_view_definition(
+      name: :active_users,
+      sql_definition: sql_definition,
+    ) do
+      example.run
+    end
+  end
+
+  it "can run migrations that create views" do
+    migration = Class.new(migration_class) do
+      def up
+        create_view :active_users
+      end
+    end
+
+    expect { run_migration(migration, :up) }.not_to raise_error
+  end
+
+  it "can run migrations that drop views" do
+    connection.create_view(:active_users)
+
+    migration = Class.new(migration_class) do
+      def up
+        drop_view :active_users
+      end
+    end
+
+    expect { run_migration(migration, :up) }.not_to raise_error
+  end
+end

--- a/spec/features/views/migrations_spec.rb
+++ b/spec/features/views/migrations_spec.rb
@@ -16,7 +16,7 @@ describe "View migrations", :db do
     EOS
     with_view_definition(
       name: :active_users,
-      sql_definition: sql_definition,
+      sql_definition: sql_definition
     ) do
       example.run
     end

--- a/spec/features/views/revert_spec.rb
+++ b/spec/features/views/revert_spec.rb
@@ -1,0 +1,82 @@
+require "spec_helper"
+
+describe "Reverting migrations", :db do
+  around do |example|
+    connection.execute <<-EOS
+      CREATE TABLE users (
+          id int PRIMARY KEY,
+          name varchar(256),
+          upper_name varchar(256),
+          active boolean
+      );
+    EOS
+    sql_definition = <<-EOS
+      CREATE VIEW active_users AS
+          SELECT * FROM users WHERE active = true;
+    EOS
+    with_view_definition(
+      name: :active_users,
+      sql_definition: sql_definition,
+    ) do
+      example.run
+    end
+  end
+
+  it "can run reversible migrations for creating views" do
+    migration = Class.new(migration_class) do
+      def change
+        create_view :active_users
+      end
+    end
+
+    expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+  end
+
+  it "can run reversible migrations for dropping views" do
+    connection.create_view(:active_users)
+
+    good_migration = Class.new(migration_class) do
+      def change
+        drop_view :active_users, revert_to_version: 1
+      end
+    end
+    bad_migration = Class.new(migration_class) do
+      def change
+        drop_view :active_users
+      end
+    end
+
+    expect { run_migration(good_migration, [:up, :down]) }.not_to raise_error
+    expect { run_migration(bad_migration, [:up, :down]) }.
+      to raise_error(
+        ActiveRecord::IrreversibleMigration,
+        /`create_view` is reversible only if given a `revert_to_version`/,
+      )
+  end
+
+  it "can run reversible migrations for updating views" do
+    connection.create_view(:active_users)
+
+    sql_definition = <<-EOS
+      CREATE VIEW active_users AS
+          SELECT id FROM users WHERE active = true;
+    EOS
+    with_view_definition(
+      name: :active_users,
+      sql_definition: sql_definition,
+      version: 2,
+    ) do
+      migration = Class.new(migration_class) do
+        def change
+          update_view(
+            :active_users,
+            version: 2,
+            revert_to_version: 1,
+          )
+        end
+      end
+
+      expect { run_migration(migration, [:up, :down]) }.not_to raise_error
+    end
+  end
+end

--- a/spec/features/views/revert_spec.rb
+++ b/spec/features/views/revert_spec.rb
@@ -16,7 +16,7 @@ describe "Reverting migrations", :db do
     EOS
     with_view_definition(
       name: :active_users,
-      sql_definition: sql_definition,
+      sql_definition: sql_definition
     ) do
       example.run
     end
@@ -47,10 +47,10 @@ describe "Reverting migrations", :db do
     end
 
     expect { run_migration(good_migration, [:up, :down]) }.not_to raise_error
-    expect { run_migration(bad_migration, [:up, :down]) }.
-      to raise_error(
+    expect { run_migration(bad_migration, [:up, :down]) }
+      .to raise_error(
         ActiveRecord::IrreversibleMigration,
-        /`create_view` is reversible only if given a `revert_to_version`/,
+        /`create_view` is reversible only if given a `revert_to_version`/
       )
   end
 
@@ -64,14 +64,14 @@ describe "Reverting migrations", :db do
     with_view_definition(
       name: :active_users,
       sql_definition: sql_definition,
-      version: 2,
+      version: 2
     ) do
       migration = Class.new(migration_class) do
         def change
           update_view(
             :active_users,
             version: 2,
-            revert_to_version: 1,
+            revert_to_version: 1
           )
         end
       end

--- a/spec/fx/adapters/postgres/views_spec.rb
+++ b/spec/fx/adapters/postgres/views_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+module Fx
+  module Adapters
+    describe Postgres::Views, :db do
+      describe ".all" do
+        it "returns `View` objects" do
+          connection = ActiveRecord::Base.connection
+          connection.execute <<-EOS.strip_heredoc
+            CREATE TABLE users (
+                id int PRIMARY KEY,
+                name varchar(256),
+                upper_name varchar(256),
+                active boolean
+            );
+
+            CREATE VIEW active_users AS
+              SELECT * FROM users WHERE active = true;
+
+            CREATE MATERIALIZED VIEW mat_active_users AS
+              SELECT * FROM users WHERE active = true;
+          EOS
+
+          views = Postgres::Views.new(connection).all
+
+          view = views.first
+          expect(views.size).to eq 2
+          expect(view.name).to eq "active_users"
+          expect(view.definition).to eq <<-EOS.strip_heredoc.rstrip
+           SELECT users.id,
+               users.name,
+               users.upper_name,
+               users.active
+              FROM users
+             WHERE (users.active = true);
+          EOS
+
+          materialized_view = views.last
+          expect(materialized_view.name).to eq "mat_active_users"
+          expect(materialized_view.definition).to eq <<-EOS.strip_heredoc.rstrip
+           SELECT users.id,
+               users.name,
+               users.upper_name,
+               users.active
+              FROM users
+             WHERE (users.active = true);
+          EOS
+        end
+
+        it "returns `View` objects for materialized view including indexes definitions" do
+          connection = ActiveRecord::Base.connection
+          connection.execute <<-EOS.strip_heredoc
+            CREATE TABLE users (
+                id int PRIMARY KEY,
+                name varchar(256),
+                upper_name varchar(256),
+                active boolean
+            );
+
+            CREATE MATERIALIZED VIEW mat_active_users AS
+              SELECT * FROM users WHERE active = true;
+
+            CREATE INDEX mat_active_users_id_index ON mat_active_users (name);
+          EOS
+
+          views = Postgres::Views.new(connection).all
+
+          materialized_view = views.last
+          expect(views.size).to eq 1
+          expect(materialized_view.name).to eq "mat_active_users"
+          expect(materialized_view.definition).to eq <<-EOS.strip_heredoc.rstrip
+           SELECT users.id,
+               users.name,
+               users.upper_name,
+               users.active
+              FROM users
+             WHERE (users.active = true);
+
+           CREATE INDEX mat_active_users_id_index ON public.mat_active_users USING btree (name);
+          EOS
+        end
+      end
+    end
+  end
+end

--- a/spec/fx/command_recorder_spec.rb
+++ b/spec/fx/command_recorder_spec.rb
@@ -168,4 +168,87 @@ describe Fx::CommandRecorder, :db do
         .to raise_error(ActiveRecord::IrreversibleMigration)
     end
   end
+
+  describe "#create_view" do
+    it "records the created view" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+
+      recorder.create_view :test
+
+      expect(recorder.commands).to eq [[:create_view, [:test], nil]]
+    end
+
+    it "reverts to drop_view" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+
+      recorder.create_view :test
+
+      expect(recorder.commands).to eq [[:create_view, [:test], nil]]
+    end
+
+    it "reverts to drop_view" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+
+      recorder.revert { recorder.create_view :test }
+
+      expect(recorder.commands).to eq [[:drop_view, [:test]]]
+    end
+  end
+
+  describe "#drop_view" do
+    it "records the dropped view" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+
+      recorder.drop_view :test
+
+      expect(recorder.commands).to eq [[:drop_view, [:test], nil]]
+    end
+
+    it "reverts to create_view with specified revert_to_version" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, { revert_to_version: 3 }]
+      revert_args = [:test, { version: 3 }]
+
+      recorder.revert { recorder.drop_view(*args) }
+
+      expect(recorder.commands).to eq [[:create_view, revert_args]]
+    end
+
+    it "raises when reverting without revert_to_version set" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, { another_argument: 1 }]
+
+      expect { recorder.revert { recorder.drop_view(*args) } }.
+        to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+
+  describe "#update_view" do
+    it "records the updated view" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, { version: 2 }]
+
+      recorder.update_view(*args)
+
+      expect(recorder.commands).to eq [[:update_view, args, nil]]
+    end
+
+    it "reverts to update_view with the specified revert_to_version" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, { version: 2, revert_to_version: 1 }]
+      revert_args = [:test, { version: 1 }]
+
+      recorder.revert { recorder.update_view(*args) }
+
+      expect(recorder.commands).to eq [[:update_view, revert_args]]
+    end
+
+    it "raises when reverting without revert_to_version set" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, { version: 42, another_argument: 1 }]
+
+      expect { recorder.revert { recorder.update_view(*args) } }.
+        to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
 end

--- a/spec/fx/command_recorder_spec.rb
+++ b/spec/fx/command_recorder_spec.rb
@@ -206,8 +206,8 @@ describe Fx::CommandRecorder, :db do
 
     it "reverts to create_view with specified revert_to_version" do
       recorder = ActiveRecord::Migration::CommandRecorder.new
-      args = [:test, { revert_to_version: 3 }]
-      revert_args = [:test, { version: 3 }]
+      args = [:test, {revert_to_version: 3}]
+      revert_args = [:test, {version: 3}]
 
       recorder.revert { recorder.drop_view(*args) }
 
@@ -216,17 +216,17 @@ describe Fx::CommandRecorder, :db do
 
     it "raises when reverting without revert_to_version set" do
       recorder = ActiveRecord::Migration::CommandRecorder.new
-      args = [:test, { another_argument: 1 }]
+      args = [:test, {another_argument: 1}]
 
-      expect { recorder.revert { recorder.drop_view(*args) } }.
-        to raise_error(ActiveRecord::IrreversibleMigration)
+      expect { recorder.revert { recorder.drop_view(*args) } }
+        .to raise_error(ActiveRecord::IrreversibleMigration)
     end
   end
 
   describe "#update_view" do
     it "records the updated view" do
       recorder = ActiveRecord::Migration::CommandRecorder.new
-      args = [:test, { version: 2 }]
+      args = [:test, {version: 2}]
 
       recorder.update_view(*args)
 
@@ -235,8 +235,8 @@ describe Fx::CommandRecorder, :db do
 
     it "reverts to update_view with the specified revert_to_version" do
       recorder = ActiveRecord::Migration::CommandRecorder.new
-      args = [:test, { version: 2, revert_to_version: 1 }]
-      revert_args = [:test, { version: 1 }]
+      args = [:test, {version: 2, revert_to_version: 1}]
+      revert_args = [:test, {version: 1}]
 
       recorder.revert { recorder.update_view(*args) }
 
@@ -245,10 +245,10 @@ describe Fx::CommandRecorder, :db do
 
     it "raises when reverting without revert_to_version set" do
       recorder = ActiveRecord::Migration::CommandRecorder.new
-      args = [:test, { version: 42, another_argument: 1 }]
+      args = [:test, {version: 42, another_argument: 1}]
 
-      expect { recorder.revert { recorder.update_view(*args) } }.
-        to raise_error(ActiveRecord::IrreversibleMigration)
+      expect { recorder.revert { recorder.update_view(*args) } }
+        .to raise_error(ActiveRecord::IrreversibleMigration)
     end
   end
 end

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -98,7 +98,7 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "view",
+          type: "view"
         )
 
         expect(definition.to_sql).to eq sql_definition
@@ -109,12 +109,12 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "view",
+          type: "view"
         )
 
         expect { definition.to_sql }.to raise_error(
           RuntimeError,
-          %r(Define view in db/views/test_v01.sql before migrating),
+          %r{Define view in db/views/test_v01.sql before migrating}
         )
       end
     end
@@ -146,7 +146,7 @@ describe Fx::Definition do
         definition = Fx::Definition.new(
           name: "test",
           version: 1,
-          type: "view",
+          type: "view"
         )
 
         expect(definition.path).to eq "db/views/test_v01.sql"

--- a/spec/fx/definition_spec.rb
+++ b/spec/fx/definition_spec.rb
@@ -86,6 +86,38 @@ describe Fx::Definition do
         )
       end
     end
+
+    context "representing a view definition" do
+      it "returns the content of a view definition" do
+        sql_definition = <<-EOS
+          CREATE VIEW active_users AS
+          SELECT * FROM users WHERE active = true;
+        EOS
+        allow(File).to receive(:read).and_return(sql_definition)
+
+        definition = Fx::Definition.new(
+          name: "test",
+          version: 1,
+          type: "view",
+        )
+
+        expect(definition.to_sql).to eq sql_definition
+      end
+
+      it "raises an error if the file is empty" do
+        allow(File).to receive(:read).and_return("")
+        definition = Fx::Definition.new(
+          name: "test",
+          version: 1,
+          type: "view",
+        )
+
+        expect { definition.to_sql }.to raise_error(
+          RuntimeError,
+          %r(Define view in db/views/test_v01.sql before migrating),
+        )
+      end
+    end
   end
 
   describe "#path" do
@@ -106,6 +138,18 @@ describe Fx::Definition do
         )
 
         expect(definition.path).to eq "db/triggers/test_v01.sql"
+      end
+    end
+
+    context "representing a view definition" do
+      it "returns a sql file with padded version and view name" do
+        definition = Fx::Definition.new(
+          name: "test",
+          version: 1,
+          type: "view",
+        )
+
+        expect(definition.path).to eq "db/views/test_v01.sql"
       end
     end
   end

--- a/spec/fx/function_spec.rb
+++ b/spec/fx/function_spec.rb
@@ -44,7 +44,7 @@ module Fx
           "definition" => "CREATE OR REPLACE TRIGGER uppercase_users_name ..."
         )
 
-        expect(function.to_schema).to eq <<-'EOS'
+        expect(function.to_schema).to eq <<-EOS
   create_function :uppercase_users_name, sql_definition: <<-'SQL'
       CREATE OR REPLACE TRIGGER uppercase_users_name ...
   SQL

--- a/spec/fx/schema_dumper/view_spec.rb
+++ b/spec/fx/schema_dumper/view_spec.rb
@@ -20,7 +20,6 @@ describe Fx::SchemaDumper::View, :db do
 
     ActiveRecord::SchemaDumper.dump(connection, stream)
 
-    output = stream.string
     expect(output).to include "create_view :active_users"
     expect(output).to include "sql_definition: <<-SQL"
     expect(output).to include "SELECT users.id"
@@ -49,7 +48,6 @@ describe Fx::SchemaDumper::View, :db do
 
     ActiveRecord::SchemaDumper.dump(connection, stream)
 
-    output = stream.string
     expect(output).to include "create_view :active_users"
     expect(output).to include "sql_definition: <<-SQL"
     expect(output).to include "SELECT users.id"

--- a/spec/fx/schema_dumper/view_spec.rb
+++ b/spec/fx/schema_dumper/view_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe Fx::SchemaDumper::View, :db do
+  it "dumps a create_view for a view in the database" do
+    connection.execute <<-EOS
+      CREATE TABLE users (
+          id int PRIMARY KEY,
+          name varchar(256),
+          upper_name varchar(256),
+          active boolean
+      );
+    EOS
+    sql_definition = <<-EOS
+      CREATE VIEW active_users AS
+        SELECT * FROM users WHERE active = true;
+    EOS
+    connection.create_view :my_view, sql_definition: sql_definition
+    stream = StringIO.new
+    output = stream.string
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+
+    output = stream.string
+    expect(output).to include "create_view :active_users"
+    expect(output).to include "sql_definition: <<-SQL"
+    expect(output).to include "SELECT users.id"
+    expect(output).to include "users.upper_name"
+    expect(output).to include "users.active"
+    expect(output).to include "FROM users"
+    expect(output).to include "WHERE (users.active = true)"
+  end
+
+  it "dumps a create_view for a materiaalized view in the database" do
+    connection.execute <<-EOS
+      CREATE TABLE users (
+          id int PRIMARY KEY,
+          name varchar(256),
+          upper_name varchar(256),
+          active boolean
+      );
+    EOS
+    sql_definition = <<-EOS
+      CREATE MATERIALIZED VIEW active_users AS
+        SELECT * FROM users WHERE active = true;
+    EOS
+    connection.create_view :my_view, sql_definition: sql_definition
+    stream = StringIO.new
+    output = stream.string
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+
+    output = stream.string
+    expect(output).to include "create_view :active_users"
+    expect(output).to include "sql_definition: <<-SQL"
+    expect(output).to include "SELECT users.id"
+    expect(output).to include "users.upper_name"
+    expect(output).to include "users.active"
+    expect(output).to include "FROM users"
+    expect(output).to include "WHERE (users.active = true)"
+  end
+end

--- a/spec/fx/statements/view_spec.rb
+++ b/spec/fx/statements/view_spec.rb
@@ -9,10 +9,10 @@ describe Fx::Statements::View, :db do
 
       connection.create_view(:test)
 
-      expect(database).to have_received(:create_view).
-        with(definition.to_sql)
-      expect(Fx::Definition).to have_received(:new).
-        with(name: :test, version: 1, type: "view")
+      expect(database).to have_received(:create_view)
+        .with(definition.to_sql)
+      expect(Fx::Definition).to have_received(:new)
+        .with(name: :test, version: 1, type: "view")
     end
 
     it "allows creating a view with a specific version" do
@@ -21,10 +21,10 @@ describe Fx::Statements::View, :db do
 
       connection.create_view(:test, version: 2)
 
-      expect(database).to have_received(:create_view).
-        with(definition.to_sql)
-      expect(Fx::Definition).to have_received(:new).
-        with(name: :test, version: 2, type: "view")
+      expect(database).to have_received(:create_view)
+        .with(definition.to_sql)
+      expect(Fx::Definition).to have_received(:new)
+        .with(name: :test, version: 2, type: "view")
     end
 
     it "raises an error if both arguments are nil" do
@@ -32,11 +32,11 @@ describe Fx::Statements::View, :db do
         connection.create_view(
           :whatever,
           version: nil,
-          sql_definition: nil,
+          sql_definition: nil
         )
       }.to raise_error(
         ArgumentError,
-        /version or sql_definition must be specified/,
+        /version or sql_definition must be specified/
       )
     end
   end
@@ -66,10 +66,10 @@ describe Fx::Statements::View, :db do
 
       connection.update_view(:test, version: 3)
 
-      expect(database).to have_received(:update_view).
-        with(:test, definition.to_sql, materialized: false)
-      expect(Fx::Definition).to have_received(:new).
-        with(name: :test, version: 3, type: "view")
+      expect(database).to have_received(:update_view)
+        .with(:test, definition.to_sql, materialized: false)
+      expect(Fx::Definition).to have_received(:new)
+        .with(name: :test, version: 3, type: "view")
     end
 
     it "updates a materialized view" do
@@ -78,10 +78,10 @@ describe Fx::Statements::View, :db do
 
       connection.update_view(:test, version: 3, materialized: true)
 
-      expect(database).to have_received(:update_view).
-        with(:test, definition.to_sql, materialized: true)
-      expect(Fx::Definition).to have_received(:new).
-        with(name: :test, version: 3, type: "view")
+      expect(database).to have_received(:update_view)
+        .with(:test, definition.to_sql, materialized: true)
+      expect(Fx::Definition).to have_received(:new)
+        .with(name: :test, version: 3, type: "view")
     end
 
     it "updates a view from a text definition" do
@@ -101,11 +101,11 @@ describe Fx::Statements::View, :db do
         connection.update_view(
           :whatever,
           version: nil,
-          sql_definition: nil,
+          sql_definition: nil
         )
       }.to raise_error(
         ArgumentError,
-        /version or sql_definition must be specified/,
+        /version or sql_definition must be specified/
       )
     end
   end

--- a/spec/fx/statements/view_spec.rb
+++ b/spec/fx/statements/view_spec.rb
@@ -1,0 +1,124 @@
+require "spec_helper"
+require "fx/statements/view"
+
+describe Fx::Statements::View, :db do
+  describe "#create_view" do
+    it "creates a view from a file" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.create_view(:test)
+
+      expect(database).to have_received(:create_view).
+        with(definition.to_sql)
+      expect(Fx::Definition).to have_received(:new).
+        with(name: :test, version: 1, type: "view")
+    end
+
+    it "allows creating a view with a specific version" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.create_view(:test, version: 2)
+
+      expect(database).to have_received(:create_view).
+        with(definition.to_sql)
+      expect(Fx::Definition).to have_received(:new).
+        with(name: :test, version: 2, type: "view")
+    end
+
+    it "raises an error if both arguments are nil" do
+      expect {
+        connection.create_view(
+          :whatever,
+          version: nil,
+          sql_definition: nil,
+        )
+      }.to raise_error(
+        ArgumentError,
+        /version or sql_definition must be specified/,
+      )
+    end
+  end
+
+  describe "#drop_view" do
+    it "drops the view" do
+      database = stubbed_database
+
+      connection.drop_view(:test)
+
+      expect(database).to have_received(:drop_view).with(:test, materialized: false)
+    end
+
+    it "drops the materialzied view" do
+      database = stubbed_database
+
+      connection.drop_view(:test, materialized: true)
+
+      expect(database).to have_received(:drop_view).with(:test, materialized: true)
+    end
+  end
+
+  describe "#update_view" do
+    it "updates the view" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.update_view(:test, version: 3)
+
+      expect(database).to have_received(:update_view).
+        with(:test, definition.to_sql, materialized: false)
+      expect(Fx::Definition).to have_received(:new).
+        with(name: :test, version: 3, type: "view")
+    end
+
+    it "updates a materialized view" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.update_view(:test, version: 3, materialized: true)
+
+      expect(database).to have_received(:update_view).
+        with(:test, definition.to_sql, materialized: true)
+      expect(Fx::Definition).to have_received(:new).
+        with(name: :test, version: 3, type: "view")
+    end
+
+    it "updates a view from a text definition" do
+      database = stubbed_database
+
+      connection.update_view(:test, sql_definition: "a definition")
+
+      expect(database).to have_received(:update_view).with(
+        :test,
+        "a definition",
+        materialized: false
+      )
+    end
+
+    it "raises an error if not supplied a version" do
+      expect {
+        connection.update_view(
+          :whatever,
+          version: nil,
+          sql_definition: nil,
+        )
+      }.to raise_error(
+        ArgumentError,
+        /version or sql_definition must be specified/,
+      )
+    end
+  end
+
+  def stubbed_database
+    instance_spy("StubbedDatabase").tap do |stubbed_database|
+      allow(Fx).to receive(:database).and_return(stubbed_database)
+    end
+  end
+
+  def stubbed_definition
+    instance_double("Fx::Definition", to_sql: nil).tap do |stubbed_definition|
+      allow(Fx::Definition).to receive(:new).and_return(stubbed_definition)
+    end
+  end
+end

--- a/spec/fx/view_spec.rb
+++ b/spec/fx/view_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+require "fx/view"
+
+module Fx
+  describe View do
+    describe "#<=>" do
+      it "delegates to `name`" do
+        view_a = View.new(
+          "name" => "name_a",
+          "definition" => "some defintion",
+        )
+        view_b = View.new(
+          "name" => "name_b",
+          "definition" => "some defintion",
+        )
+        view_c = View.new(
+          "name" => "name_c",
+          "definition" => "some defintion",
+        )
+
+        expect(view_b).to be_between(view_a, view_c)
+      end
+    end
+
+    describe "#==" do
+      it "compares `name` and `definition`" do
+        view_a = View.new(
+          "name" => "name_a",
+          "definition" => "some defintion",
+        )
+        view_b = View.new(
+          "name" => "name_b",
+          "definition" => "some other defintion",
+        )
+
+        expect(view_a).not_to eq(view_b)
+      end
+    end
+
+    describe "#to_schema" do
+      context 'when it is a materialized view' do
+        it "returns a schema compatible version of the materialized view" do
+          view = View.new(
+            "name" => "active_users",
+            "definition" => "SELECT * FROM users ...",
+            "materialized" => true
+          )
+
+          expect(view.to_schema).to eq <<-EOS
+  create_view :active_users, sql_definition: <<-\SQL
+      CREATE MATERIALIZED VIEW active_users AS
+      SELECT * FROM users ...
+  SQL
+          EOS
+        end
+      end
+
+      context 'when it is not a materialized view' do
+        it "returns a schema compatible version of the view" do
+          view = View.new(
+            "name" => "active_users",
+            "definition" => "SELECT * FROM users ...",
+          )
+
+          expect(view.to_schema).to eq <<-EOS
+  create_view :active_users, sql_definition: <<-\SQL
+      CREATE VIEW active_users AS
+      SELECT * FROM users ...
+  SQL
+          EOS
+        end
+      end
+    end
+  end
+end

--- a/spec/fx/view_spec.rb
+++ b/spec/fx/view_spec.rb
@@ -7,15 +7,15 @@ module Fx
       it "delegates to `name`" do
         view_a = View.new(
           "name" => "name_a",
-          "definition" => "some defintion",
+          "definition" => "some defintion"
         )
         view_b = View.new(
           "name" => "name_b",
-          "definition" => "some defintion",
+          "definition" => "some defintion"
         )
         view_c = View.new(
           "name" => "name_c",
-          "definition" => "some defintion",
+          "definition" => "some defintion"
         )
 
         expect(view_b).to be_between(view_a, view_c)
@@ -26,11 +26,11 @@ module Fx
       it "compares `name` and `definition`" do
         view_a = View.new(
           "name" => "name_a",
-          "definition" => "some defintion",
+          "definition" => "some defintion"
         )
         view_b = View.new(
           "name" => "name_b",
-          "definition" => "some other defintion",
+          "definition" => "some other defintion"
         )
 
         expect(view_a).not_to eq(view_b)
@@ -38,7 +38,7 @@ module Fx
     end
 
     describe "#to_schema" do
-      context 'when it is a materialized view' do
+      context "when it is a materialized view" do
         it "returns a schema compatible version of the materialized view" do
           view = View.new(
             "name" => "active_users",
@@ -55,11 +55,11 @@ module Fx
         end
       end
 
-      context 'when it is not a materialized view' do
+      context "when it is not a materialized view" do
         it "returns a schema compatible version of the view" do
           view = View.new(
             "name" => "active_users",
-            "definition" => "SELECT * FROM users ...",
+            "definition" => "SELECT * FROM users ..."
           )
 
           expect(view.to_schema).to eq <<-EOS

--- a/spec/generators/fx/view/view_generator_spec.rb
+++ b/spec/generators/fx/view/view_generator_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "generators/fx/view/view_generator"
+
+describe Fx::Generators::ViewGenerator, :generator do
+  it "creates a view definition file, and a migration" do
+    migration = file("db/migrate/create_view_test.rb")
+    view_definition = file("db/views/test_v01.sql")
+
+    run_generator ["test"]
+
+    expect(view_definition).to exist
+    expect(migration).to be_a_migration
+
+    migration_file = migration_file(migration)
+    expect(migration_file).to contain "CreateViewTest"
+    expect(migration_file).to contain "create_view :test\n"
+  end
+
+  context "when passed --materialized" do
+    it "creates a materialized view definition file" do
+      migration = file("db/migrate/create_view_test.rb")
+      view_definition = file("db/views/test_v01.sql")
+
+      run_generator ["test", "--materialized"]
+
+      expect(view_definition).to exist
+      expect(migration).to be_a_migration
+
+      migration_file = migration_file(migration)
+      expect(migration_file).to contain "CreateViewTest"
+      expect(migration_file).to contain "create_view :test, materialized: true\n"
+    end
+  end
+
+  context "when passed --no-migration" do
+    it "creates a only view definition file" do
+      migration = file("db/migrate/create_view_test.rb")
+      view_definition = file("db/views/test_v01.sql")
+
+      run_generator ["test", "--no-migration"]
+
+      expect(view_definition).to exist
+      expect(migration_file(migration)).not_to exist
+    end
+  end
+
+  it "updates an existing view" do
+    with_view_definition(
+      name: "test",
+      version: 1,
+      sql_definition: "hello",
+    ) do
+      allow(Dir).to receive(:entries).and_return(["test_v01.sql"])
+      migration = file("db/migrate/update_view_test_to_version_2.rb")
+      view_definition = file("db/views/test_v02.sql")
+
+      run_generator ["test"]
+
+      expect(view_definition).to exist
+      expect(migration).to be_a_migration
+      expect(migration_file(migration)).
+        to contain("UpdateViewTestToVersion2")
+    end
+  end
+end

--- a/spec/generators/fx/view/view_generator_spec.rb
+++ b/spec/generators/fx/view/view_generator_spec.rb
@@ -48,7 +48,7 @@ describe Fx::Generators::ViewGenerator, :generator do
     with_view_definition(
       name: "test",
       version: 1,
-      sql_definition: "hello",
+      sql_definition: "hello"
     ) do
       allow(Dir).to receive(:entries).and_return(["test_v01.sql"])
       migration = file("db/migrate/update_view_test_to_version_2.rb")
@@ -58,8 +58,8 @@ describe Fx::Generators::ViewGenerator, :generator do
 
       expect(view_definition).to exist
       expect(migration).to be_a_migration
-      expect(migration_file(migration)).
-        to contain("UpdateViewTestToVersion2")
+      expect(migration_file(migration))
+        .to contain("UpdateViewTestToVersion2")
       expect(migration_file(migration)).to contain "update_view :test, version: 2, revert_to_version: 1"
     end
   end
@@ -82,7 +82,7 @@ describe Fx::Generators::ViewGenerator, :generator do
     with_view_definition(
       name: "foo_test",
       version: 1,
-      sql_definition: "hello",
+      sql_definition: "hello"
     ) do
       allow(Dir).to receive(:entries).and_return(["foo_test_v01.sql"])
       migration = file("db/migrate/update_view_foo_test_to_version_2.rb")
@@ -92,8 +92,8 @@ describe Fx::Generators::ViewGenerator, :generator do
 
       expect(view_definition).to exist
       expect(migration).to be_a_migration
-      expect(migration_file(migration)).
-        to contain("UpdateViewFooTestToVersion2")
+      expect(migration_file(migration))
+        .to contain("UpdateViewFooTestToVersion2")
       expect(migration_file(migration)).to contain 'update_view "foo.test", version: 2, revert_to_version: 1'
     end
   end

--- a/spec/support/definition_helpers.rb
+++ b/spec/support/definition_helpers.rb
@@ -23,6 +23,20 @@ module DefinitionHelpers
     )
   end
 
+  def with_view_definition(name:, sql_definition:, version: 1, &block)
+    definition = Fx::Definition.new(
+      name: name,
+      version: version,
+      type: "view",
+    )
+
+    with_definition(
+      definition: definition,
+      sql_definition: sql_definition,
+      block: block,
+    )
+  end
+
   def with_definition(definition:, sql_definition:, block:)
     FileUtils.mkdir_p(File.dirname(definition.full_path))
     File.write(definition.full_path, sql_definition)

--- a/spec/support/definition_helpers.rb
+++ b/spec/support/definition_helpers.rb
@@ -27,13 +27,13 @@ module DefinitionHelpers
     definition = Fx::Definition.new(
       name: name,
       version: version,
-      type: "view",
+      type: "view"
     )
 
     with_definition(
       definition: definition,
       sql_definition: sql_definition,
-      block: block,
+      block: block
     )
   end
 


### PR DESCRIPTION
This resurrects @comogo work from https://github.com/teoljungberg/fx/pull/69, with just some minor updates to bring it up to date with `master`.

@teoljungberg, I know you originally closed #69 and recommended using Scenic instead. That makes sense, but I'm wondering if you'd be open to revisiting this due to some specific use-cases where fx's approach seems to make things easier. Namely, it revolves around similar needs brought up in https://github.com/scenic-views/scenic/issues/338 involving permissions on views, but it doesn't seem like Scenic has a desire to handle (which is fair).

Basically, for situations where you need to perform `GRANT` statements on materialized views, you need to execute those grants every time your materialized view is updated or replaced (since materialized views have to be dropped and then recreated, so it doesn't retain the original permissions). But here's how things compare between Scenic and fx and why fx with these changes feels like it works better for this use-case:

- In Scenic the SQL file is *only* the `SELECT` statement that defines the view. There cannot be any other SQL statements in the SQL file definition, so if you want to perform extra logic in the same transaction, like `GRANT` statements, then those  would need to be added to the Ruby migration file as `execute` statements.

  While that can work, the downside of this approach is that since these extra GRANT statements are in the migration file, that means this logic is not automatically copied when you add a new migration to update the view. Only the SQL file definition is copied between migration versions, so unless you're careful to track down the previous Ruby migration file and copy extra `execute` statements from there into your new migration file, it's easy for permissions to go missing when updating views.

  And I can understand why this would be a complicated feature to add to Scenic due to how the SQL file only defines the `SELECT` statement. So for similar reasons that supporting indices are tricky for materialized view (since Scenic needs to query the database for indices before and then re-create them afterwards), I can see why this would be more of a pain to handle in Scenic.
- With fx's approach and this work from @comogo, this all seems simpler to handle without jumping through extra hoops. Because fx will execute the SQL definition file fully (rather than making assumptions that it only includes the `SELECT` statement), then you simply need to include any `GRANT` or `CREATE INDEX` statements in the SQL definition file. Since any future update migrations will copy that full SQL file, then any custom permissions or indices will automatically be retained since they're simply part of the SQL definition file (so you don't need to have any custom logic in the Ruby migration file).

If this still feels like an edge-case you're not interested in supporting, then I understand, but it does seem like fx's approach does lend itself to handling views and materialized views in a nice way that isn't too complicated (since most of the details are being deferred to the SQL definition files, but we still can benefit from fx's versioning approach).

Thanks!