### PR TITLE
Require Rails >= 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
         ruby: ["3.0", "3.1", "3.2"]
         rails: ["6.1", "7.0"]
         continue-on-error: [false]
-        exclude:
-          - ruby: "3.2"
-            rails: "6.1"
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2"]
-        rails: ["6.0", "6.1", "7.0"]
+        rails: ["6.1", "7.0"]
         continue-on-error: [false]
         exclude:
           - ruby: "3.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
         continue-on-error: [false]
         exclude:
           - ruby: "3.2"
-            rails: "6.0"
-          - ruby: "3.2"
             rails: "6.1"
 
     services:

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard"
   spec.add_development_dependency "warning"
 
-  spec.add_dependency "activerecord", ">= 6.0.0"
-  spec.add_dependency "railties", ">= 6.0.0"
+  spec.add_dependency "activerecord", ">= 6.1"
+  spec.add_dependency "railties", ">= 6.1"
 
   spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Rails < 6.1 (and 6.0 specifically) hit EOL on 1/6/2023.