### PR TITLE
Add Rubygems metadata to fx.gemspec

### DIFF
--- a/fx.gemspec
+++ b/fx.gemspec
@@ -14,6 +14,12 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage = "https://github.com/teoljungberg/fx"
   spec.license = "MIT"
+  spec.metadata = {
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/blob/v#{spec.version}/CHANGELOG.md",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,    
+  }
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This adds those little clickable links to the Rubygems gem page.

I picked the "version-specific URL to changelog".