### PR TITLE
Support for `SET LOCAL check_function_bodies`

### DIFF
--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -40,9 +40,23 @@ module Fx
     # @return Boolean
     attr_accessor :dump_functions_at_beginning_of_schema
 
+    # Check function bodies during creation by issuing
+    # `SET LOCAL check_function_bodies TO <<value>>;` before creating functions.
+    #
+    # See https://stackoverflow.com/a/36983831 and
+    # https://www.postgresql.org/docs/9.5/runtime-config-client.html#GUC-CHECK-FUNCTION-BODIES
+    #
+    # Set to `nil` to use the database default configuration.
+    # The default and recommended value is `false` to mimic pg_dump's behavior.
+    #
+    # Defaults to false
+    # @return Boolean, nil
+    attr_accessor :check_function_bodies
+
     def initialize
       @database = Fx::Adapters::Postgres.new
       @dump_functions_at_beginning_of_schema = false
+      @check_function_bodies = false
     end
   end
 end

--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -18,9 +18,22 @@ module Fx
     def to_schema
       <<~SCHEMA.indent(2)
         create_function :#{name}, sql_definition: <<-'SQL'
-        #{definition.indent(4).rstrip}
+        #{definition_with_check_function_bodies(definition).indent(4).rstrip}
         SQL
       SCHEMA
+    end
+
+    private
+
+    def definition_with_check_function_bodies(definition)
+      should_wrap = [true, false].include?(Fx.configuration.check_function_bodies)
+      return definition unless should_wrap
+
+      output = []
+      output << "BEGIN;\n" + "SET LOCAL check_function_bodies TO #{Fx.configuration.check_function_bodies};\n".indent(4)
+      output << definition.indent(4).rstrip + ";"
+      output << "COMMIT;"
+      output.join("\n")
     end
   end
 end

--- a/lib/fx/schema_dumper/function.rb
+++ b/lib/fx/schema_dumper/function.rb
@@ -23,12 +23,8 @@ module Fx
       end
 
       def functions(stream)
-        return unless dumpable_functions_in_database.any?
-
-        wrap_with_check_function_bodies(stream) do
-          dumpable_functions_in_database.each do |function|
-            stream.puts(function.to_schema)
-          end
+        dumpable_functions_in_database.each do |function|
+          stream.puts(function.to_schema)
         end
       end
 
@@ -36,20 +32,6 @@ module Fx
 
       def dumpable_functions_in_database
         @_dumpable_functions_in_database ||= Fx.database.functions
-      end
-
-      def wrap_with_check_function_bodies(stream)
-        should_wrap = [true, false].include?(Fx.configuration.check_function_bodies) && dumpable_functions_in_database.any?
-
-        if should_wrap && Fx.configuration.check_function_bodies
-          stream.puts("BEGIN;\nSET LOCAL check_function_bodies TO true;")
-        elsif should_wrap && !Fx.configuration.check_function_bodies
-          stream.puts("BEGIN;\nSET LOCAL check_function_bodies TO false;")
-        end
-
-        yield
-
-        stream.puts("COMMIT;") if should_wrap
       end
     end
   end

--- a/lib/fx/schema_dumper/function.rb
+++ b/lib/fx/schema_dumper/function.rb
@@ -23,8 +23,12 @@ module Fx
       end
 
       def functions(stream)
-        dumpable_functions_in_database.each do |function|
-          stream.puts(function.to_schema)
+        return unless dumpable_functions_in_database.any?
+
+        wrap_with_check_function_bodies(stream) do
+          dumpable_functions_in_database.each do |function|
+            stream.puts(function.to_schema)
+          end
         end
       end
 
@@ -32,6 +36,20 @@ module Fx
 
       def dumpable_functions_in_database
         @_dumpable_functions_in_database ||= Fx.database.functions
+      end
+
+      def wrap_with_check_function_bodies(stream)
+        should_wrap = [true, false].include?(Fx.configuration.check_function_bodies) && dumpable_functions_in_database.any?
+
+        if should_wrap && Fx.configuration.check_function_bodies
+          stream.puts("BEGIN;\nSET LOCAL check_function_bodies TO true;")
+        elsif should_wrap && !Fx.configuration.check_function_bodies
+          stream.puts("BEGIN;\nSET LOCAL check_function_bodies TO false;")
+        end
+
+        yield
+
+        stream.puts("COMMIT;") if should_wrap
       end
     end
   end

--- a/spec/fx/function_spec.rb
+++ b/spec/fx/function_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Fx::Function do
         "definition" => "CREATE OR REPLACE TRIGGER uppercase_users_name ..."
       )
 
+      Fx.configuration.check_function_bodies = nil
+
       expect(function.to_schema).to eq <<-EOS
   create_function :uppercase_users_name, sql_definition: <<-'SQL'
       CREATE OR REPLACE TRIGGER uppercase_users_name ...
@@ -54,6 +56,8 @@ RSpec.describe Fx::Function do
         "name" => "regex",
         "definition" => "CREATE OR REPLACE FUNCTION regex \\1"
       )
+
+      Fx.configuration.check_function_bodies = nil
 
       expect(function.to_schema).to eq <<-'EOS'
   create_function :regex, sql_definition: <<-'SQL'

--- a/spec/fx/schema_dumper/function_spec.rb
+++ b/spec/fx/schema_dumper/function_spec.rb
@@ -65,12 +65,11 @@ RSpec.describe Fx::SchemaDumper::Function, :db do
       output = stream.string
 
       ActiveRecord::SchemaDumper.dump(connection, stream)
-
-      expect(output).to match(
-        /BEGIN;\n*SET LOCAL check_function_bodies TO false;.*\n*.*create_function/
+      expect(output.gsub(/^ +/, '')).to match(
+        /BEGIN;\n*SET LOCAL check_function_bodies TO false;\n*CREATE OR REPLACE FUNCTION/
       )
 
-      expect(output).to match(/\$function\$\n+\s*SQL\n*.*COMMIT;/)
+      expect(output.gsub(/^ +/, '')).to match(/\$function\$;\n+.*COMMIT;\n+SQL/)
     end
   ensure
     Fx.configuration.check_function_bodies = true
@@ -94,11 +93,11 @@ RSpec.describe Fx::SchemaDumper::Function, :db do
 
       ActiveRecord::SchemaDumper.dump(connection, stream)
 
-      expect(output).to match(
-        /BEGIN;\n*SET LOCAL check_function_bodies TO true;.*\n*.*create_function/
+      expect(output.gsub(/^ +/, '')).to match(
+        /BEGIN;\n*SET LOCAL check_function_bodies TO true;\n*CREATE OR REPLACE FUNCTION/
       )
 
-      expect(output).to match(/\$function\$\n+\s*SQL\n*.*COMMIT;/)
+      expect(output.gsub(/^ +/, '')).to match(/\$function\$;\n+.*COMMIT;\n+SQL/)
     end
   ensure
     Fx.configuration.check_function_bodies = true

--- a/spec/fx/schema_dumper/function_spec.rb
+++ b/spec/fx/schema_dumper/function_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 
+# rubocop:disable Metrics/BlockLength
+
 RSpec.describe Fx::SchemaDumper::Function, :db do
   it "dumps a create_function for a function in the database" do
     sql_definition = <<-EOS
@@ -46,6 +48,90 @@ RSpec.describe Fx::SchemaDumper::Function, :db do
     Fx.configuration.dump_functions_at_beginning_of_schema = false
   end
 
+  context "when check_function_bodies is false" do
+    it "outputs `SET LOCAL check_function_bodies TO false`" do
+      Fx.configuration.check_function_bodies = false
+
+      sql_definition = <<-EOS
+          CREATE OR REPLACE FUNCTION my_function()
+          RETURNS text AS $$
+          BEGIN
+              RETURN 'test';
+          END;
+          $$ LANGUAGE plpgsql;
+      EOS
+      connection.create_function :my_function, sql_definition: sql_definition
+      stream = StringIO.new
+      output = stream.string
+
+      ActiveRecord::SchemaDumper.dump(connection, stream)
+
+      expect(output).to match(
+        /BEGIN;\n*SET LOCAL check_function_bodies TO false;.*\n*.*create_function/
+      )
+
+      expect(output).to match(/\$function\$\n+\s*SQL\n*.*COMMIT;/)
+    end
+  ensure
+    Fx.configuration.check_function_bodies = true
+  end
+
+  context "when check_function_bodies is true" do
+    it "outputs `SET LOCAL check_function_bodies TO true`" do
+      Fx.configuration.check_function_bodies = true
+
+      sql_definition = <<-EOS
+          CREATE OR REPLACE FUNCTION my_function()
+          RETURNS text AS $$
+          BEGIN
+              RETURN 'test';
+          END;
+          $$ LANGUAGE plpgsql;
+      EOS
+      connection.create_function :my_function, sql_definition: sql_definition
+      stream = StringIO.new
+      output = stream.string
+
+      ActiveRecord::SchemaDumper.dump(connection, stream)
+
+      expect(output).to match(
+        /BEGIN;\n*SET LOCAL check_function_bodies TO true;.*\n*.*create_function/
+      )
+
+      expect(output).to match(/\$function\$\n+\s*SQL\n*.*COMMIT;/)
+    end
+  ensure
+    Fx.configuration.check_function_bodies = true
+  end
+
+  context "when check_function_bodies is nil" do
+    it "does not output `SET LOCAL check_function_bodies`" do
+      Fx.configuration.check_function_bodies = nil
+
+      sql_definition = <<-EOS
+          CREATE OR REPLACE FUNCTION my_function()
+          RETURNS text AS $$
+          BEGIN
+              RETURN 'test';
+          END;
+          $$ LANGUAGE plpgsql;
+      EOS
+      connection.create_function :my_function, sql_definition: sql_definition
+      stream = StringIO.new
+      output = stream.string
+
+      ActiveRecord::SchemaDumper.dump(connection, stream)
+
+      expect(output).not_to match(
+        /SET LOCAL check_function_bodies/
+      )
+
+      expect(output).not_to match(/COMMIT;/)
+    end
+  ensure
+    Fx.configuration.check_function_bodies = true
+  end
+
   it "does not dump a create_function for aggregates in the database" do
     sql_definition = <<-EOS
       CREATE OR REPLACE FUNCTION test(text, text)
@@ -76,3 +162,5 @@ RSpec.describe Fx::SchemaDumper::Function, :db do
     expect(output).not_to include "aggregate_test"
   end
 end
+
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Added a new configuration parameter `check_function_bodies` to allow controlling the database behavior when loading functions.

This is necessary if the function created relies on the existence of a table that is not yet created, for example.

Disabling `check_function_bodies` is `pg_dump`'s default behaviour and, in my opinion, should be Fx's default behavior as well.
