### PR TITLE
Add Rails 7.1 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2"]
-        rails: ["6.1", "7.0"]
+        rails: ["6.1", "7.0", "7.1"]
         continue-on-error: [false]
 
     services:

--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -27,8 +27,8 @@ module Fx
         # Wraps #all as a static facade.
         #
         # @return [Array<Fx::Function>]
-        def self.all(*args)
-          new(*args).all
+        def self.all(...)
+          new(...).all
         end
 
         def initialize(connection)

--- a/lib/fx/adapters/postgres/triggers.rb
+++ b/lib/fx/adapters/postgres/triggers.rb
@@ -25,8 +25,8 @@ module Fx
         # Wraps #all as a static facade.
         #
         # @return [Array<Fx::Trigger>]
-        def self.all(*args)
-          new(*args).all
+        def self.all(...)
+          new(...).all
         end
 
         def initialize(connection)

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,6 +12,8 @@ module Dummy
     config.eager_load = false
     config.active_support.deprecation = :stderr
 
-    config.active_record.legacy_connection_handling = false
+    if Rails.version <= "7.0.0"
+      config.active_record.legacy_connection_handling = false
+    end
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,7 +12,7 @@ module Dummy
     config.eager_load = false
     config.active_support.deprecation = :stderr
 
-    if Rails.version <= "7.0.0"
+    if Rails.version <= "7.0"
       config.active_record.legacy_connection_handling = false
     end
   end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,6 +12,8 @@ module Dummy
     config.eager_load = false
     config.active_support.deprecation = :stderr
 
+    config.load_defaults 7.0
+
     if Rails.version <= "7.0"
       config.active_record.legacy_connection_handling = false
     end


### PR DESCRIPTION
https://github.com/rails/rails/releases/tag/v7.1.0

Changes:
- Appease standard by using `...`. I will investigate why it is needed
  for these 2 cases in a separate PR.