### PR TITLE
Sort functions and triggers by their name when dumping them to the schema

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -21,7 +21,7 @@ module Fx
               ON pa.aggfnoid = pp.oid
           WHERE pn.nspname = 'public' AND pd.objid IS NULL
               AND pa.aggfnoid IS NULL
-          ORDER BY pp.oid;
+          ORDER BY pp.proname;
         EOS
 
         # Wraps #all as a static facade.

--- a/lib/fx/adapters/postgres/triggers.rb
+++ b/lib/fx/adapters/postgres/triggers.rb
@@ -19,7 +19,7 @@ module Fx
               ON (pp.oid = pt.tgfoid)
           WHERE pt.tgname
           NOT ILIKE '%constraint%' AND pt.tgname NOT ILIKE 'pg%'
-          ORDER BY pc.oid;
+          ORDER BY pt.tgname;
         EOS
 
         # Wraps #all as a static facade.

--- a/spec/fx/adapters/postgres/functions_spec.rb
+++ b/spec/fx/adapters/postgres/functions_spec.rb
@@ -13,21 +13,23 @@ RSpec.describe Fx::Adapters::Postgres::Functions, :db do
         $$ LANGUAGE plpgsql;
       EOS
 
+      connection.execute <<-EOS.strip_heredoc
+        CREATE OR REPLACE FUNCTION foo()
+        RETURNS text AS $$
+        BEGIN
+            RETURN 'foo';
+        END;
+        $$ LANGUAGE plpgsql;
+      EOS
+
       functions = Fx::Adapters::Postgres::Functions.new(connection).all
 
-      first = functions.first
-      expect(functions.size).to eq 1
-      expect(first.name).to eq "test"
-      expect(first.definition).to eq <<-EOS.strip_heredoc
-        CREATE OR REPLACE FUNCTION public.test()
-         RETURNS text
-         LANGUAGE plpgsql
-        AS $function$
-        BEGIN
-            RETURN 'test';
-        END;
-        $function$
-      EOS
+      expect(functions).to match(
+        [
+          an_object_having_attributes(name: "foo", definition: a_string_matching(/CREATE OR REPLACE FUNCTION public.foo()/)),
+          an_object_having_attributes(name: "test", definition: a_string_matching(/CREATE OR REPLACE FUNCTION public.test()/))
+        ]
+      )
     end
   end
 end


### PR DESCRIPTION
This is my first contribution to F(x), so please let me know if I missed anything!

Active Record's schema dumping approach is to output all elements in a deterministic order, sorted by the name of the element (enum, table, etc.).

F(x) has been fetching functions and triggers by insertion order (`oid`), and while that can often work fine, a situation we've run into is when we restore our database from a dump (say, from staging / production). `pg_dump` will output the functions and triggers in their alphabetical order rather than based on creation order.

This causes a lot of churn in `db/schema.rb` if you're consistently leaning on a dumped database to do local development:

* Engineer 1 creates the function `a()` alongside existing function `b()`, which is added to `db/schema.rb` in the order `b(), a()`
* Engineer 2 starts working on something that needs fresh production data, and so dumps the database to his local machine
* Engineer 2 sets up the development database, and while doing so, `db/schema.rb` is regenerated, causing the functions to switch their order to `a(), b()`
* Engineer 1 continues to work off of their same local database, and while doing so, causes `db/schema.rb` to again regenerate, causing the functions to switch their order back to `b(), a()`

Since the order of the functions themselves doesn't actually matter (you can reference functions that don't yet exist in the body of a function), following the established name-ordered pattern of `db/schema.rb` eliminates this churn in `db/schema.rb`, regardless of whether you work off of a production (or production-like) database dump, or not.