### PR TITLE
Schema-dump all functions within search_path, not just 'public'

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -19,7 +19,17 @@ module Fx
               ON pd.objid = pp.oid AND pd.deptype = 'e'
           LEFT JOIN pg_aggregate pa
               ON pa.aggfnoid = pp.oid
-          WHERE pn.nspname = 'public' AND pd.objid IS NULL
+          WHERE pn.nspname
+              IN (
+                  SELECT replace(
+                      unnest(string_to_array(setting, ', ')),
+                      '"$user"',
+                      current_user
+                  )
+                  FROM pg_settings
+                  WHERE name = 'search_path'
+              )
+              AND pd.objid IS NULL
               AND pa.aggfnoid IS NULL
           ORDER BY pp.oid;
         EOS

--- a/spec/fx/adapters/postgres/functions_spec.rb
+++ b/spec/fx/adapters/postgres/functions_spec.rb
@@ -29,5 +29,93 @@ RSpec.describe Fx::Adapters::Postgres::Functions, :db do
         $function$
       EOS
     end
+
+    context "when functions are in a different schema" do
+      it "does not return the `Function` objects" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-EOS.strip_heredoc
+          CREATE SCHEMA test_schema;
+          CREATE OR REPLACE FUNCTION test_schema.test()
+          RETURNS text AS $$
+          BEGIN
+              RETURN 'test';
+          END;
+          $$ LANGUAGE plpgsql;
+        EOS
+
+        functions = Fx::Adapters::Postgres::Functions.new(connection).all
+
+        expect(functions).to be_empty
+      end
+
+      context "when the other schema is in the search path" do
+        it "returns the `Function` objects" do
+          connection = ActiveRecord::Base.connection
+          connection.execute <<-EOS.strip_heredoc
+            CREATE SCHEMA test_schema;
+            SET search_path TO public,test_schema;
+            CREATE OR REPLACE FUNCTION test_schema.test()
+            RETURNS text AS $$
+            BEGIN
+                RETURN 'test';
+            END;
+            $$ LANGUAGE plpgsql;
+          EOS
+
+          functions = Fx::Adapters::Postgres::Functions.new(connection).all
+
+          first = functions.first
+          expect(functions.size).to eq 1
+          expect(first.name).to eq "test"
+          expect(first.definition).to eq <<-EOS.strip_heredoc
+            CREATE OR REPLACE FUNCTION test_schema.test()
+             RETURNS text
+             LANGUAGE plpgsql
+            AS $function$
+            BEGIN
+                RETURN 'test';
+            END;
+            $function$
+          EOS
+        ensure
+          ActiveRecord::Base.connection.execute 'SET search_path TO "$user", public'
+        end
+      end
+
+      context 'when the other schema is the "$user" (dynamic) schema' do
+        it "returns the `Function` objects" do
+          connection = ActiveRecord::Base.connection
+          current_user = connection.execute("SELECT current_user").first["current_user"]
+          connection.execute <<-EOS.strip_heredoc
+            CREATE SCHEMA #{current_user};
+            SET search_path TO "$user",public;
+            CREATE OR REPLACE FUNCTION #{current_user}.test()
+            RETURNS text AS $$
+            BEGIN
+                RETURN 'test';
+            END;
+            $$ LANGUAGE plpgsql;
+          EOS
+
+          functions = Fx::Adapters::Postgres::Functions.new(connection).all
+
+          first = functions.first
+          expect(functions.size).to eq 1
+          expect(first.name).to eq "test"
+          expect(first.definition).to eq <<-EOS.strip_heredoc
+            CREATE OR REPLACE FUNCTION #{current_user}.test()
+             RETURNS text
+             LANGUAGE plpgsql
+            AS $function$
+            BEGIN
+                RETURN 'test';
+            END;
+            $function$
+          EOS
+        ensure
+          ActiveRecord::Base.connection.execute 'SET search_path TO "$user", public'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
For an application relying on `schema.rb`, this gem will dump only functions in the hardcoded `public` schema. This means that an application with tables in other pg schemas (and/or an application with a nonstandard schema search path) may be able to create a function with `create_function` that does not survive the round-trip to `schema.rb`, in turn breaking the app after `db:schema:load`.

One workaround is to use `structure.sql` (which relies on `pg_dump`) to dump the functions in all schemas. However, because the postgres `search_path` is accessible from within a query, this PR proposes using that value to dump all functions within the current `search_path`. This allows the end-developer to continue using `schema.rb` while inserting functions into multiple PG schemas, and is backwards compatible with the prior `= 'public'` check (assuming `public` is in the search path, which it is by default).

**Alternatives considered:**
- Filter functions not by namespace, but by owner, and only dump functions owned by the current user.
- Look up grants and only dump (non-information-schema) functions granted to the current user (or to the PUBLIC role).
- Use `pg_dump` (or Rails' code that executes `pg_dump`) and extract functions. However, this implementation actually uses `search_path` to construct the `--schema=` argument for the command, which is how I came full circle back to using `search_path` in this PR. It actually matches what Rails does in its Ruby logic for producing `structure.sql`:
    ```ruby
    args += search_path.split(",").map do |part|
      "--schema=#{part.strip}"
    end
    ```
    ([source](https://github.com/rails/rails/blob/66e5ed7fa94fcc972729707c7218fa061b715cff/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb#L63-L64))