### PR TITLE
Fix deprecation warnings

### DIFF
--- a/spec/generators/fx/function/function_generator_spec.rb
+++ b/spec/generators/fx/function/function_generator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fx::Generators::FunctionGenerator, :generator do
       run_generator ["test", "--no-migration"]
 
       expect(function_definition).to exist
-      expect(migration_file(migration)).not_to exist
+      expect(Pathname.new(migration_file(migration))).not_to exist
     end
   end
 

--- a/spec/generators/fx/trigger/trigger_generator_spec.rb
+++ b/spec/generators/fx/trigger/trigger_generator_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Fx::Generators::TriggerGenerator, :generator do
       run_generator ["test", {"table_name" => "some_table"}, "--no-migration"]
 
       expect(trigger_definition).to exist
-      expect(migration_file(migration)).not_to exist
+      expect(Pathname.new(migration_file(migration))).not_to exist
     end
   end
 


### PR DESCRIPTION
> DEPRECATION WARNING: The `exist` matcher overrides one built-in by
> RSpec; use `expect(Pathname.new(path)).to exist` instead