### PR TITLE
Refactor configuration tests

### DIFF
--- a/lib/fx.rb
+++ b/lib/fx.rb
@@ -22,6 +22,8 @@ module Fx
     ActiveRecord::Migration::CommandRecorder.include(Fx::CommandRecorder)
     ActiveRecord::ConnectionAdapters::AbstractAdapter.include(Fx::Statements)
     ActiveRecord::SchemaDumper.prepend(Fx::SchemaDumper)
+
+    true
   end
 
   # @return [Fx::Configuration] F(x)'s current configuration

--- a/spec/fx/configuration_spec.rb
+++ b/spec/fx/configuration_spec.rb
@@ -2,20 +2,31 @@ require "spec_helper"
 
 RSpec.describe Fx::Configuration do
   it "defaults the database adapter to postgres" do
-    expect(Fx.configuration.database).to be_a(Fx::Adapters::Postgres)
-    expect(Fx.database).to be_a(Fx::Adapters::Postgres)
+    configuration = Fx::Configuration.new
+
+    expect(configuration.database).to be_a(Fx::Adapters::Postgres)
+  end
+
+  it "defaults `dump_functions_at_beginning_of_schema` to false" do
+    configuration = Fx::Configuration.new
+
+    expect(configuration.dump_functions_at_beginning_of_schema).to eq(false)
   end
 
   it "allows the database adapter to be set" do
+    configuration = Fx::Configuration.new
     adapter = double("Fx Adapter")
 
-    Fx.configure do |config|
-      config.database = adapter
-    end
+    configuration.database = adapter
 
-    expect(Fx.configuration.database).to eq(adapter)
-    expect(Fx.database).to eq(adapter)
+    expect(configuration.database).to eq(adapter)
+  end
 
-    Fx.configuration = Fx::Configuration.new
+  it "allows `dump_functions_at_beginning_of_schema` to be set" do
+    configuration = Fx::Configuration.new
+
+    configuration.dump_functions_at_beginning_of_schema = true
+
+    expect(configuration.dump_functions_at_beginning_of_schema).to eq(true)
   end
 end

--- a/spec/fx_spec.rb
+++ b/spec/fx_spec.rb
@@ -22,5 +22,7 @@ RSpec.describe Fx do
 
     expect(Fx.configuration.database).to eq(adapter)
     expect(Fx.configuration.dump_functions_at_beginning_of_schema).to eq(true)
+
+    Fx.configuration = nil
   end
 end

--- a/spec/fx_spec.rb
+++ b/spec/fx_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Fx do
+  it "has a version number" do
+    expect(Fx::VERSION).to be_present
+  end
+
+  it "loads fx into ActiveRecord" do
+    expect(ActiveRecord::Migration::CommandRecorder).to include(Fx::CommandRecorder)
+    expect(ActiveRecord::ConnectionAdapters::AbstractAdapter).to include(Fx::Statements)
+    expect(ActiveRecord::SchemaDumper).to include(Fx::SchemaDumper)
+    expect(Fx.load).to eq(true)
+  end
+
+  it "allows configuration" do
+    adapter = double("Fx Adapter")
+
+    Fx.configure do |config|
+      config.database = adapter
+      config.dump_functions_at_beginning_of_schema = true
+    end
+
+    expect(Fx.configuration.database).to eq(adapter)
+    expect(Fx.configuration.dump_functions_at_beginning_of_schema).to eq(true)
+  end
+end


### PR DESCRIPTION
- Add explicit return value of `Fx.load`. Returning true over
  `ActiveRecord::SchemaDumper` feels more expected.
- Test Fx's configuration per file.