### PR TITLE
Bump Rails support to Rails 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-preview2"]
-        rails: ["6.1", "7.0", "7.1", "7.2", "8.0.0"]
+        rails: ["7.0", "7.1", "7.2", "8.0.0"]
         continue-on-error: [false]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-preview2"]
-        rails: ["6.1", "7.0", "7.1", "7.2", "8.0.0.rc2"]
+        rails: ["6.1", "7.0", "7.1", "7.2", "8.0.0"]
         continue-on-error: [false]
 
     services:

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0")
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 6.1"
-  spec.add_dependency "railties", ">= 6.1"
+  spec.add_dependency "activerecord", ">= 7.0"
+  spec.add_dependency "railties", ">= 7.0"
 
   spec.required_ruby_version = ">= 3.0"
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -13,5 +13,9 @@ module Dummy
     config.active_support.deprecation = :stderr
 
     config.load_defaults 7.0
+
+    if Rails.version >= "8.0"
+      config.active_support.to_time_preserves_timezone = :zone
+    end
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -13,9 +13,5 @@ module Dummy
     config.active_support.deprecation = :stderr
 
     config.load_defaults 7.0
-
-    if Rails.version <= "7.0"
-      config.active_record.legacy_connection_handling = false
-    end
   end
 end


### PR DESCRIPTION
Changes:
- Drop support for Rails 6.2 to keep with the end of life policy.