### PR TITLE
Feature/added support for apartment gem

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -11,7 +11,8 @@ module Fx
         FUNCTIONS_WITH_DEFINITIONS_QUERY = <<~EOS.freeze
           SELECT
               pp.proname AS name,
-              pg_get_functiondef(pp.oid) AS definition
+              pg_get_functiondef(pp.oid) AS definition,
+              current_schema() AS current_schema
           FROM pg_proc pp
           JOIN pg_namespace pn
               ON pn.oid = pp.pronamespace
@@ -19,7 +20,7 @@ module Fx
               ON pd.objid = pp.oid AND pd.deptype = 'e'
           LEFT JOIN pg_aggregate pa
               ON pa.aggfnoid = pp.oid
-          WHERE pn.nspname = 'public' AND pd.objid IS NULL
+          WHERE pn.nspname = current_schema AND pd.objid IS NULL
               AND pa.aggfnoid IS NULL
           ORDER BY pp.oid;
         EOS

--- a/lib/fx/function.rb
+++ b/lib/fx/function.rb
@@ -3,12 +3,13 @@ module Fx
   class Function
     include Comparable
 
-    attr_reader :name, :definition
+    attr_reader :name, :definition, :current_schema
     delegate :<=>, to: :name
 
     def initialize(row)
       @name = row.fetch("name")
       @definition = row.fetch("definition")
+      @current_schema = row.fetch("current_schema")
     end
 
     def ==(other)
@@ -18,7 +19,7 @@ module Fx
     def to_schema
       <<~SCHEMA.indent(2)
         create_function :#{name}, sql_definition: <<-'SQL'
-        #{definition.indent(4).rstrip}
+          #{definition.indent(4).rstrip.gsub("#{current_schema}.", 'public.')}
         SQL
       SCHEMA
     end

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -13,8 +13,6 @@ module Fx
         functions(stream)
         empty_line(stream)
       end
-
-      triggers(stream)
     end
 
     private

--- a/lib/fx/trigger.rb
+++ b/lib/fx/trigger.rb
@@ -16,10 +16,13 @@ module Fx
     end
 
     def to_schema
+      definition = self.definition.gsub('public.', '')
+      function_name = definition.split('FUNCTION ')[-1].split(".")[-1]
+      definition.gsub!(function_name, "public.#{function_name}")
       <<-SCHEMA
-  create_trigger :#{name}, sql_definition: <<-\SQL
-      #{definition}
-  SQL
+        create_trigger :#{name}, sql_definition: <<-\SQL
+          #{definition}
+        SQL
       SCHEMA
     end
   end


### PR DESCRIPTION
* By default the gem add function with public as schema in schema.rb. At the time of creating a new tenant, system tries to load schema but fails to find method.

* Added a tweak to support Apartment Gem by appending public. to function in trigger in schema.rb

---------