### PR TITLE
Add support for multi db setups with a different adapter

### DIFF
--- a/fx.gemspec
+++ b/fx.gemspec
@@ -27,5 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.0"
   spec.add_dependency "railties", ">= 7.0"
 
+  spec.add_development_dependency "sqlite3"
+
   spec.required_ruby_version = ">= 3.0"
 end

--- a/lib/fx.rb
+++ b/lib/fx.rb
@@ -21,7 +21,7 @@ module Fx
   def self.load
     ActiveRecord::Migration::CommandRecorder.include(Fx::CommandRecorder)
     ActiveRecord::ConnectionAdapters::AbstractAdapter.include(Fx::Statements)
-    ActiveRecord::SchemaDumper.prepend(Fx::SchemaDumper)
+    ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper.prepend(Fx::SchemaDumper)
 
     true
   end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -7,5 +7,10 @@ development: &default
   pool: 5
 
 test:
-  <<: *default
-  database: dummy_test
+  primary:
+    <<: *default
+    database: dummy_test
+  sqlite:
+    adapter: sqlite3
+    database: ":memory:"
+    migrations_paths: db/migrate/sqlite

--- a/spec/fx/schema_dumper_spec.rb
+++ b/spec/fx/schema_dumper_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe Fx::SchemaDumper, :db do
     expect(output).to include("EXECUTE FUNCTION uppercase_users_name()")
   end
 
+  context "with a sqlite adapter" do
+    before(:each) { ActiveRecord::Base.establish_connection(:sqlite) }
+    after(:each) { ActiveRecord::Base.establish_connection(:primary) }
+
+    it "does not dump functions or triggers for SQLite connections" do
+      connection.create_table :my_table
+
+      stream = StringIO.new
+      dump(connection: connection, stream: stream)
+
+      output = stream.string
+
+      expect(output).to include('create_table "my_table"')
+    end
+  end
+
   def dump(connection:, stream:)
     if Rails.version >= "7.2"
       ActiveRecord::SchemaDumper.dump(connection.pool, stream)

--- a/spec/fx_spec.rb
+++ b/spec/fx_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Fx do
   it "loads fx into ActiveRecord" do
     expect(ActiveRecord::Migration::CommandRecorder).to include(Fx::CommandRecorder)
     expect(ActiveRecord::ConnectionAdapters::AbstractAdapter).to include(Fx::Statements)
-    expect(ActiveRecord::SchemaDumper).to include(Fx::SchemaDumper)
+    expect(ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper).to include(Fx::SchemaDumper)
     expect(Fx.load).to eq(true)
   end
 


### PR DESCRIPTION
I was implementing solid_cable using SQLite as an adapter and came across this issue, where the schema dumper was trying to dump the functions and triggers for the SQLite solid cable schema. Obviously, this isn't possible.

I've modified the code to hook into the `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper` instead of the generic `ActiveRecord::SchemaDumper` and added a test

This should also fix #155