### PR TITLE
Update supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
-        rails: ["7.0", "7.1", "7.2", "8.0.0"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        rails: ["7.1", "7.2", "8.0.0"]
         continue-on-error: [false]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.1", "3.2", "3.3", "3.4"]
-        rails: ["7.1", "7.2", "8.0.0"]
+        rails: ["7.1", "7.2", "8.0"]
         continue-on-error: [false]
 
     services:

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.0"
   spec.add_dependency "railties", ">= 7.0"
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 end


### PR DESCRIPTION
We are dropping support for EOL'd Ruby and Rails versions, but keeping
those that still receive security updates due to that not causing extra
maintenance.

Changes:
- Require Ruby >= 3.1
- Drop EOL Ruby version (3.0)
- Drop EOL Rails version (7.0)
- Relax Rails 8's version requirement