### PR TITLE
Adds Rails 6.1 if_exists flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,17 @@ tweak the schema in the new definition and run the `update_function` migration.
 
 ## I don't need this trigger or function anymore. Make it go away.
 
-F(x) gives you `drop_trigger` and `drop_function` too:
+F(x) gives you `drop_trigger`, `drop_function`, and `drop_function_if_exists` too:
 
 ```ruby
 def change
   drop_function :uppercase_users_name, revert_to_version: 2
+end
+```
+
+```ruby
+def up
+  drop_function_if_exists :uppercase_users_name, revert_to_version: 2
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,17 +77,15 @@ tweak the schema in the new definition and run the `update_function` migration.
 
 ## I don't need this trigger or function anymore. Make it go away.
 
-F(x) gives you `drop_trigger`, `drop_function`, and `drop_function_if_exists` too:
+F(x) gives you `drop_trigger` and `drop_function` too. These support the Rails 6.1 `if_exists: true` flags
 
 ```ruby
 def change
   drop_function :uppercase_users_name, revert_to_version: 2
 end
-```
 
-```ruby
 def up
-  drop_function_if_exists :uppercase_users_name, revert_to_version: 2
+  drop_function :users_first_name, revert_to_version: 2, if_exists: true
 end
 ```
 

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -132,6 +132,23 @@ module Fx
         end
       end
 
+      # Drops the function from the database if it exists.
+      # Does NOT raise an error if the function doesn't exist.
+      #
+      # This is typically called in a migration via
+      # {Fx::Statements::Function#drop_function_if_exists}.
+      #
+      # @param name The name of the function to drop
+      #
+      # @return [void]
+      def drop_function_if_exists(name)
+        if connection.support_drop_function_without_args
+          execute("DROP FUNCTION IF EXISTS #{name};")
+        else
+          execute("DROP FUNCTION IF EXISTS #{name}();")
+        end
+      end
+
       # Drops the trigger from the database
       #
       # This is typically called in a migration via

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -122,30 +122,14 @@ module Fx
       # {Fx::Statements::Function#drop_function}.
       #
       # @param name The name of the function to drop
+      # @param if_exists If true, will not raise an error if the function does not exist
       #
       # @return [void]
-      def drop_function(name)
+      def drop_function(name, if_exists: false)
         if connection.support_drop_function_without_args
-          execute("DROP FUNCTION #{name};")
+          execute("DROP FUNCTION #{if_exists ? 'IF EXISTS ' : ' '}#{name};")
         else
-          execute("DROP FUNCTION #{name}();")
-        end
-      end
-
-      # Drops the function from the database if it exists.
-      # Does NOT raise an error if the function doesn't exist.
-      #
-      # This is typically called in a migration via
-      # {Fx::Statements::Function#drop_function_if_exists}.
-      #
-      # @param name The name of the function to drop
-      #
-      # @return [void]
-      def drop_function_if_exists(name)
-        if connection.support_drop_function_without_args
-          execute("DROP FUNCTION IF EXISTS #{name};")
-        else
-          execute("DROP FUNCTION IF EXISTS #{name}();")
+          execute("DROP FUNCTION #{if_exists ? 'IF EXISTS ' : ' '}#{name}();")
         end
       end
 
@@ -156,10 +140,11 @@ module Fx
       #
       # @param name The name of the trigger to drop
       # @param on The associated table for the trigger to drop
+      # @param if_exists If true, will not raise an error if the trigger does not exist
       #
       # @return [void]
-      def drop_trigger(name, on:)
-        execute("DROP TRIGGER #{name} ON #{on};")
+      def drop_trigger(name, on:, if_exists: false)
+        execute("DROP TRIGGER #{if_exists ? 'IF EXISTS ' : ' '}#{name} ON #{on};")
       end
 
       private

--- a/lib/fx/command_recorder.rb
+++ b/lib/fx/command_recorder.rb
@@ -9,6 +9,10 @@ module Fx
       record(:drop_function, args)
     end
 
+    def drop_function_if_exists(*args)
+      record(:drop_function_if_exists, args)
+    end
+
     def update_function(*args)
       record(:update_function, args)
     end
@@ -18,6 +22,10 @@ module Fx
     end
 
     def invert_drop_function(args)
+      perform_inversion(:create_function, args)
+    end
+
+    def invert_drop_function_if_exists(args)
       perform_inversion(:create_function, args)
     end
 

--- a/lib/fx/command_recorder.rb
+++ b/lib/fx/command_recorder.rb
@@ -9,10 +9,6 @@ module Fx
       record(:drop_function, args)
     end
 
-    def drop_function_if_exists(*args)
-      record(:drop_function_if_exists, args)
-    end
-
     def update_function(*args)
       record(:update_function, args)
     end
@@ -22,10 +18,6 @@ module Fx
     end
 
     def invert_drop_function(args)
-      perform_inversion(:create_function, args)
-    end
-
-    def invert_drop_function_if_exists(args)
       perform_inversion(:create_function, args)
     end
 

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -57,6 +57,22 @@ module Fx
       Fx.database.drop_function(name)
     end
 
+    # Drop a database function by name if it exists. This will NOT raise an error
+    # if the function does not exist in postgres allowing future migrations to succeed.
+    #
+    # @param name [String, Symbol] The name of the database function.
+    # @param revert_to_version [Fixnum] Used to reverse the `drop_function`
+    #   command on `rake db:rollback`. The provided version will be passed as
+    #   the `version` argument to {#create_function}.
+    # @return The database response from executing the drop statement.
+    #
+    # @example Drop a function, rolling back to version 2 on rollback
+    #   drop_function_if_exists(:uppercase_users_name, revert_to_version: 2)
+    #
+    def drop_function_if_exists(name, options = {})
+      Fx.database.drop_function_if_exists(name)
+    end
+
     # Update a database function.
     #
     # @param name [String, Symbol] The name of the database function.

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -57,7 +57,7 @@ module Fx
     #   drop_function(:uppercase_users_name, if_exists: true)
     #
     def drop_function(name, options = {})
-      if_exists = options.fetch(:if_exists)
+      if_exists = options.fetch(:if_exists, false)
       Fx.database.drop_function(name, if_exists: if_exists)
     end
 
@@ -169,7 +169,7 @@ module Fx
     #
     def drop_trigger(name, options = {})
       on = options.fetch(:on)
-      if_exists = options.fetch(:if_exists)
+      if_exists = options.fetch(:if_exists, false)
       Fx.database.drop_trigger(name, on: on, if_exists: if_exists)
     end
 

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -53,24 +53,12 @@ module Fx
     # @example Drop a function, rolling back to version 2 on rollback
     #   drop_function(:uppercase_users_name, revert_to_version: 2)
     #
+    # @example Drop a function only if it exists
+    #   drop_function(:uppercase_users_name, if_exists: true)
+    #
     def drop_function(name, options = {})
-      Fx.database.drop_function(name)
-    end
-
-    # Drop a database function by name if it exists. This will NOT raise an error
-    # if the function does not exist in postgres allowing future migrations to succeed.
-    #
-    # @param name [String, Symbol] The name of the database function.
-    # @param revert_to_version [Fixnum] Used to reverse the `drop_function`
-    #   command on `rake db:rollback`. The provided version will be passed as
-    #   the `version` argument to {#create_function}.
-    # @return The database response from executing the drop statement.
-    #
-    # @example Drop a function, rolling back to version 2 on rollback
-    #   drop_function_if_exists(:uppercase_users_name, revert_to_version: 2)
-    #
-    def drop_function_if_exists(name, options = {})
-      Fx.database.drop_function_if_exists(name)
+      if_exists = options.fetch(:if_exists)
+      Fx.database.drop_function(name, if_exists: if_exists)
     end
 
     # Update a database function.
@@ -176,9 +164,13 @@ module Fx
     # @example Drop a trigger, rolling back to version 3 on rollback
     #   drop_trigger(:log_inserts, on: :users, revert_to_version: 3)
     #
+    # @example Drop a trigger only if it exists
+    #   drop_trigger(:log_inserts, on: :users, if_exists: true)
+    #
     def drop_trigger(name, options = {})
       on = options.fetch(:on)
-      Fx.database.drop_trigger(name, on: on)
+      if_exists = options.fetch(:if_exists)
+      Fx.database.drop_trigger(name, on: on, if_exists: if_exists)
     end
 
     # Update a database trigger to a new version.

--- a/spec/features/functions/migrations_spec.rb
+++ b/spec/features/functions/migrations_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Function migrations", :db do
   it "can run migrations that drop functions without raising an error" do
     migration = Class.new(migration_class) do
       def up
-        drop_function_if_exists :test # test has not been created
+        drop_function :test, if_exists: true # test has not been created
       end
     end
 

--- a/spec/features/functions/migrations_spec.rb
+++ b/spec/features/functions/migrations_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe "Function migrations", :db do
     expect { run_migration(migration, :up) }.not_to raise_error
   end
 
+  it "can run migrations that drop functions without raising an error" do
+    migration = Class.new(migration_class) do
+      def up
+        drop_function_if_exists :test # test has not been created
+      end
+    end
+
+    expect { run_migration(migration, :up) }.not_to raise_error
+  end
+
   it "can run migrations that updates functions" do
     connection.create_function(:test)
 

--- a/spec/features/functions/revert_spec.rb
+++ b/spec/features/functions/revert_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe "Reverting migrations", :db do
       )
   end
 
+  it "can run reversible migrations for dropping functions with if_exists" do
+    connection.create_function(:test)
+
+    good_migration = Class.new(migration_class) do
+      def change
+        drop_function :test, revert_to_version: 1, if_exists: true
+      end
+    end
+
+    expect { run_migration(good_migration, [:up, :down]) }.not_to raise_error
+  end
+
   it "can run reversible migrations for updating functions" do
     connection.create_function(:test)
 

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -91,53 +91,11 @@ RSpec.describe Fx::Adapters::Postgres, :db do
         expect(adapter.functions.map(&:name)).not_to include("test")
       end
     end
-  end
 
-  describe "#drop_function_if_exists" do
-    context "when the function has arguments" do
-      it "successfully drops a function with the entire function signature" do
+    context "when the function does not exist" do
+      it "successfully drops a function with if_exists = true" do
         adapter = Fx::Adapters::Postgres.new
-        adapter.create_function(
-          <<~EOS
-            CREATE FUNCTION adder(x int, y int)
-            RETURNS int AS $$
-            BEGIN
-                RETURN $1 + $2;
-            END;
-            $$ LANGUAGE plpgsql;
-          EOS
-        )
-
-        adapter.drop_function_if_exists(:adder)
-
-        expect(adapter.functions.map(&:name)).not_to include("adder")
-      end
-    end
-
-    context "when the function does not have arguments" do
-      it "successfully drops a function" do
-        adapter = Fx::Adapters::Postgres.new
-        adapter.create_function(
-          <<~EOS
-            CREATE OR REPLACE FUNCTION test()
-            RETURNS text AS $$
-            BEGIN
-                RETURN 'test';
-            END;
-            $$ LANGUAGE plpgsql;
-          EOS
-        )
-
-        adapter.drop_function_if_exists(:test)
-
-        expect(adapter.functions.map(&:name)).not_to include("test")
-      end
-    end
-
-    context "when function does not exists" do
-      it "does not raise an error" do
-        adapter = Fx::Adapters::Postgres.new
-        adapter.drop_function_if_exists(:test)
+        adapter.drop_function(:test, if_exists: true)
 
         expect(adapter.functions.map(&:name)).not_to include("test")
       end

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -93,6 +93,57 @@ RSpec.describe Fx::Adapters::Postgres, :db do
     end
   end
 
+  describe "#drop_function_if_exists" do
+    context "when the function has arguments" do
+      it "successfully drops a function with the entire function signature" do
+        adapter = Fx::Adapters::Postgres.new
+        adapter.create_function(
+          <<~EOS
+            CREATE FUNCTION adder(x int, y int)
+            RETURNS int AS $$
+            BEGIN
+                RETURN $1 + $2;
+            END;
+            $$ LANGUAGE plpgsql;
+          EOS
+        )
+
+        adapter.drop_function_if_exists(:adder)
+
+        expect(adapter.functions.map(&:name)).not_to include("adder")
+      end
+    end
+
+    context "when the function does not have arguments" do
+      it "successfully drops a function" do
+        adapter = Fx::Adapters::Postgres.new
+        adapter.create_function(
+          <<~EOS
+            CREATE OR REPLACE FUNCTION test()
+            RETURNS text AS $$
+            BEGIN
+                RETURN 'test';
+            END;
+            $$ LANGUAGE plpgsql;
+          EOS
+        )
+
+        adapter.drop_function_if_exists(:test)
+
+        expect(adapter.functions.map(&:name)).not_to include("test")
+      end
+    end
+
+    context "when function does not exists" do
+      it "does not raise an error" do
+        adapter = Fx::Adapters::Postgres.new
+        adapter.drop_function_if_exists(:test)
+
+        expect(adapter.functions.map(&:name)).not_to include("test")
+      end
+    end
+  end
+
   describe "#functions" do
     it "finds functions and builds Fx::Function objects" do
       adapter = Fx::Adapters::Postgres.new

--- a/spec/fx/statements_spec.rb
+++ b/spec/fx/statements_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Fx::Statements, :db do
     end
   end
 
+  describe "#drop_function_if_exists" do
+    it "drops the function if it exists" do
+      database = stubbed_database
+
+      connection.drop_function_if_exists(:test)
+
+      expect(database).to have_received(:drop_function_if_exists).with(:test)
+    end
+  end
+
   describe "#update_function" do
     it "updates the function" do
       database = stubbed_database

--- a/spec/fx/statements_spec.rb
+++ b/spec/fx/statements_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Fx::Statements, :db do
 
       connection.drop_function(:test)
 
-      expect(database).to have_received(:drop_function).with(:test)
+      expect(database).to have_received(:drop_function).with(:test, if_exists: false)
     end
 
     it "drops the function with if_exists" do
@@ -142,7 +142,7 @@ RSpec.describe Fx::Statements, :db do
       connection.drop_trigger(:test, on: :users)
 
       expect(database).to have_received(:drop_trigger)
-        .with(:test, on: :users)
+        .with(:test, on: :users, if_exists: false)
     end
 
     it "drops the trigger with if_exists" do

--- a/spec/fx/statements_spec.rb
+++ b/spec/fx/statements_spec.rb
@@ -48,15 +48,13 @@ RSpec.describe Fx::Statements, :db do
 
       expect(database).to have_received(:drop_function).with(:test)
     end
-  end
 
-  describe "#drop_function_if_exists" do
-    it "drops the function if it exists" do
+    it "drops the function with if_exists" do
       database = stubbed_database
 
-      connection.drop_function_if_exists(:test)
+      connection.drop_function(:test, if_exists: true)
 
-      expect(database).to have_received(:drop_function_if_exists).with(:test)
+      expect(database).to have_received(:drop_function).with(:test, if_exists: true)
     end
   end
 
@@ -145,6 +143,15 @@ RSpec.describe Fx::Statements, :db do
 
       expect(database).to have_received(:drop_trigger)
         .with(:test, on: :users)
+    end
+
+    it "drops the trigger with if_exists" do
+      database = stubbed_database
+
+      connection.drop_trigger(:test, on: :users, if_exists: true)
+
+      expect(database).to have_received(:drop_trigger)
+        .with(:test, on: :users, if_exists: true)
     end
   end
 


### PR DESCRIPTION
Rails 6.1 added `if_exists` flags to things like `remove_column` to assist with edge cases of migrations where the column was removed and possibly not readded in a rollback; basically putting your entire migration in a state of failure. Just ran across this with this gem, so this seems like a good addition.

Blog post showing how the `if_exists` flag works.
https://blog.saeloun.com/2020/02/10/rails-support-for-if-exists-if-not-exists-on-remove-column-add-column-in-migrations