### PR TITLE
Bump minimum requirement to Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
         rails: ["7.1", "7.2", "8.0"]
         continue-on-error: [false]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ changelog, see the [commits] for each version via the version links.
 
 [Unreleased]: https://github.com/teoljungberg/fx/compare/v0.9.0..HEAD
 
+- Require Ruby >= 3.2 (#166)
 - Add Ruby 3.4 to the test matrix (#161)
 - Require Ruby >= 3.1 (#162)
 - Drop EOL Ruby versions (3.0) (#162)

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.0"
   spec.add_dependency "railties", ">= 7.0"
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 end


### PR DESCRIPTION
Ruby 3.1 got EOL'd 31/3/2025