### PR TITLE
Scope functions and triggers to schema search path

### DIFF
--- a/lib/fx/adapters/postgres/functions.rb
+++ b/lib/fx/adapters/postgres/functions.rb
@@ -19,7 +19,8 @@ module Fx
               ON pd.objid = pp.oid AND pd.deptype = 'e'
           LEFT JOIN pg_aggregate pa
               ON pa.aggfnoid = pp.oid
-          WHERE pn.nspname = 'public' AND pd.objid IS NULL
+          WHERE pn.nspname = ANY (current_schemas(false))
+              AND pd.objid IS NULL
               AND pa.aggfnoid IS NULL
           ORDER BY pp.oid;
         EOS

--- a/lib/fx/adapters/postgres/triggers.rb
+++ b/lib/fx/adapters/postgres/triggers.rb
@@ -17,8 +17,11 @@ module Fx
               ON (pc.oid = pt.tgrelid)
           JOIN pg_proc pp
               ON (pp.oid = pt.tgfoid)
-          WHERE pt.tgname
-          NOT ILIKE '%constraint%' AND pt.tgname NOT ILIKE 'pg%'
+          JOIN pg_namespace pn
+              ON pn.oid = pc.relnamespace
+          WHERE pn.nspname = ANY (current_schemas(false))
+              AND pt.tgname NOT ILIKE '%constraint%'
+              AND pt.tgname NOT ILIKE 'pg%'
           ORDER BY pc.oid;
         EOS
 

--- a/spec/fx/adapters/postgres/functions_spec.rb
+++ b/spec/fx/adapters/postgres/functions_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Fx::Adapters::Postgres::Functions, :db do
         END;
         $function$
       EOS
+
+      connection.execute "CREATE SCHEMA IF NOT EXISTS other;"
+      connection.execute "SET search_path = 'other';"
+
+      functions = Fx::Adapters::Postgres::Functions.new(connection).all
+
+      expect(functions).to be_empty
+
+      connection.execute "SET search_path = 'public';"
     end
   end
 end

--- a/spec/fx/adapters/postgres/triggers_spec.rb
+++ b/spec/fx/adapters/postgres/triggers_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Fx::Adapters::Postgres::Triggers, :db do
       expect(first.definition).to match(/ON [public.ser|]/)
       expect(first.definition).to include("FOR EACH ROW")
       expect(first.definition).to include("EXECUTE FUNCTION uppercase_users_name()")
+
+      connection.execute "CREATE SCHEMA IF NOT EXISTS other;"
+      connection.execute "SET search_path = 'other';"
+
+      triggers = Fx::Adapters::Postgres::Triggers.new(connection).all
+
+      expect(triggers).to be_empty
+
+      connection.execute "SET search_path = 'public';"
     end
   end
 end


### PR DESCRIPTION
Updates the function and trigger queries for PostgreSQL to only return objects from the current schema search path.

This is based on how Rails limits dumping objects like enums (rails/rails#47791).

Resolves #164.