### PR TITLE
ensure multi-schema dumping in Rails 8.1.0 doesn't dump the same objects for all schemas

### DIFF
--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -4,14 +4,12 @@ module Fx
     def tables(stream)
       if Fx.configuration.dump_functions_at_beginning_of_schema
         functions(stream)
-        empty_line(stream)
       end
 
       super
 
       unless Fx.configuration.dump_functions_at_beginning_of_schema
         functions(stream)
-        empty_line(stream)
       end
 
       triggers(stream)
@@ -19,17 +17,19 @@ module Fx
 
     private
 
-    def empty_line(stream)
-      stream.puts if dumpable_functions_in_database.any?
-    end
-
     def functions(stream)
+      dumpable_functions_in_database = Fx.database.functions
+
       dumpable_functions_in_database.each do |function|
         stream.puts(function.to_schema)
       end
+
+      stream.puts if dumpable_functions_in_database.any?
     end
 
     def triggers(stream)
+      dumpable_triggers_in_database = Fx.database.triggers
+
       if dumpable_triggers_in_database.any?
         stream.puts
       end
@@ -37,14 +37,6 @@ module Fx
       dumpable_triggers_in_database.each do |trigger|
         stream.puts(trigger.to_schema)
       end
-    end
-
-    def dumpable_functions_in_database
-      @_dumpable_functions_in_database ||= Fx.database.functions
-    end
-
-    def dumpable_triggers_in_database
-      @_dumpable_triggers_in_database ||= Fx.database.triggers
     end
   end
 end

--- a/spec/fx/schema_dumper_spec.rb
+++ b/spec/fx/schema_dumper_spec.rb
@@ -113,6 +113,60 @@ RSpec.describe Fx::SchemaDumper, :db do
     expect(output).to include("EXECUTE FUNCTION uppercase_users_name()")
   end
 
+  context "when there are functions / triggers in multiple schemas" do
+    before { connection.schema_search_path = "public,test_schema" }
+
+    after { connection.schema_search_path = "public" }
+
+    it "dumps functions and triggers for multiple schemas" do
+      connection.create_table :my_table
+
+      connection.create_function :test1, sql_definition: <<~EOS
+        CREATE OR REPLACE FUNCTION test_public_func()
+        RETURNS TRIGGER AS $$
+        BEGIN
+          RETURN 1;
+        END;
+        $$ LANGUAGE plpgsql;
+      EOS
+      connection.create_trigger :test1_trigger, sql_definition: <<~EOS
+        CREATE TRIGGER test_public_trigger
+        BEFORE INSERT ON my_table
+        FOR EACH ROW
+        EXECUTE FUNCTION test_public_func();
+      EOS
+
+      connection.execute("CREATE SCHEMA test_schema;")
+
+      connection.create_table "test_schema.my_table2"
+
+      connection.execute <<~EOS
+        CREATE OR REPLACE FUNCTION test_schema.test_schema_func()
+        RETURNS TRIGGER AS $$
+        BEGIN
+          RETURN 'test_schema';
+        END;
+        $$ LANGUAGE plpgsql;
+      EOS
+      connection.execute <<~EOS
+        CREATE TRIGGER test_schema_trigger
+        BEFORE INSERT ON test_schema.my_table2
+        FOR EACH ROW
+        EXECUTE FUNCTION test_schema.test_schema_func();
+      EOS
+
+      stream = StringIO.new
+      dump(connection: connection, stream: stream)
+      output = stream.string
+
+      expect(output.scan("create_function :test_public_func").size).to eq(1)
+      expect(output.scan("create_trigger :test_public_trigger").size).to eq(1)
+
+      expect(output.scan("create_function :test_schema_func").size).to eq(1)
+      expect(output.scan("create_trigger :test_schema_trigger").size).to eq(1)
+    end
+  end
+
   def dump(connection:, stream:)
     if Rails.version >= "7.2"
       ActiveRecord::SchemaDumper.dump(connection.pool, stream)


### PR DESCRIPTION
In Rails 8.1.0, `bin/rails db:schema:dump` now knows how to dump multiple schemas (rails/rails#50020). To ensure we don't dump the same functions / triggers for each schema, we need to stop memoizing `Fx.database.{functions,triggers}`.

This should be fully backwards compatible to previous Rails versions, as we still only call each of those methods once per schema dumping invocation, it just now works if schema dumping is invoked multiple times.