### PR TITLE
Extract validation methods in Statements module

### DIFF
--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -227,7 +227,7 @@ module Fx
         when :trigger
           Fx::Definition.trigger(name: name, version: version)
         else
-          raise ArgumentError, "Unknown type: #{type}. Must be :function or :trigger"
+          raise ArgumentError, "Unknown type: #{type}. Must be :function or :trigger", caller
         end
 
       definition.to_sql


### PR DESCRIPTION
Refactor the Statements module to reduce code duplication and improve
maintainability by extracting repeated validation and SQL resolution logic.

Changes:
- Extract error message constants
- Extract validation methods
- Extract `resolve_sql_definition` method to handle SQL definition resolution
- Simplify conditional logic (e.g., `version ||= 1` instead of if/nil check)
- Remove unused `_on` variable in `create_trigger`