### PR TITLE
Add configurable function sorter for schema dumper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changelog, see the [commits] for each version via the version links.
   schema.rb (#197)
 - Internal refactorings / improvements
   - Add PostgreSQL 18 to CI test matrix
+  - Simplify conditional function dumping in SchemaDumper (#200)
 
 ## [0.10.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ changelog, see the [commits] for each version via the version links.
 - Add PostgreSQL versioning policy, officially supporting PostgreSQL 14-18
 - Refactor Statements module to use explicit keyword arguments instead of `**options` hash (#186)
 - Add `config.function_sorter` to allow custom function ordering in
-  schema.rb (#197)
+  schema.rb (#197, #200)
 - Internal refactorings / improvements
   - Add PostgreSQL 18 to CI test matrix
   - Simplify conditional function dumping in SchemaDumper (#200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ changelog, see the [commits] for each version via the version links.
   schema.rb (#197, #200)
 - Internal refactorings / improvements
   - Add PostgreSQL 18 to CI test matrix
-  - Simplify conditional function dumping in SchemaDumper (#200)
 
 ## [0.10.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changelog, see the [commits] for each version via the version links.
 
 - Add PostgreSQL versioning policy, officially supporting PostgreSQL 14-18
 - Refactor Statements module to use explicit keyword arguments instead of `**options` hash (#186)
+- Add `config.function_sorter` to allow custom function ordering in
+  schema.rb (#197)
 - Internal refactorings / improvements
   - Add PostgreSQL 18 to CI test matrix
 

--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -16,7 +16,7 @@ module Fx
     attr_accessor :dump_functions_at_beginning_of_schema
 
     # A callable that sorts functions before they are dumped to schema.rb.
-    # Must respond to `#call(functions)` and return a sorted array of
+    # Must respond to `.call(functions)` and return a sorted array of
     # {Fx::Function} objects.
     #
     # Defaults to nil (no sorting, preserves database order).

--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -15,9 +15,18 @@ module Fx
     # @return [Boolean] Boolean
     attr_accessor :dump_functions_at_beginning_of_schema
 
+    # A callable that sorts functions before they are dumped to schema.rb.
+    # Must respond to `#call(functions)` and return a sorted array of
+    # {Fx::Function} objects.
+    #
+    # Defaults to nil (no sorting, preserves database order).
+    # @return [#call, nil] Function sorter
+    attr_accessor :function_sorter
+
     def initialize
       @database = Fx::Adapters::Postgres.new
       @dump_functions_at_beginning_of_schema = false
+      @function_sorter = nil
     end
   end
 end

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -25,15 +25,15 @@ module Fx
     end
 
     def sorted_functions(functions)
-      return functions unless (sorter = Fx.configuration.function_sorter)
-
-      sorter.call(functions)
+      if (function_sorter = Fx.configuration.function_sorter)
+        function_sorter.call(functions)
+      else
+        functions
+      end
     end
 
     def triggers(stream)
-      dumpable_triggers_in_database = Fx.database.triggers
-
-      dumpable_triggers_in_database.each do |trigger|
+      Fx.database.triggers.each do |trigger|
         stream.puts
         stream.puts(trigger.to_schema)
       end

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -18,12 +18,16 @@ module Fx
     private
 
     def functions(stream)
-      dumpable_functions_in_database = Fx.database.functions
-
-      dumpable_functions_in_database.each do |function|
+      sorted_functions(Fx.database.functions).each do |function|
         stream.puts
         stream.puts(function.to_schema)
       end
+    end
+
+    def sorted_functions(functions)
+      return functions unless (sorter = Fx.configuration.function_sorter)
+
+      sorter.call(functions)
     end
 
     def triggers(stream)

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -4,11 +4,9 @@ module Fx
     def tables(stream)
       if Fx.configuration.dump_functions_at_beginning_of_schema
         functions(stream)
-      end
-
-      super
-
-      unless Fx.configuration.dump_functions_at_beginning_of_schema
+        super
+      else
+        super
         functions(stream)
       end
 

--- a/spec/fx/configuration_spec.rb
+++ b/spec/fx/configuration_spec.rb
@@ -29,4 +29,19 @@ RSpec.describe Fx::Configuration do
 
     expect(configuration.dump_functions_at_beginning_of_schema).to eq(true)
   end
+
+  it "defaults `function_sorter` to nil" do
+    configuration = Fx::Configuration.new
+
+    expect(configuration.function_sorter).to be_nil
+  end
+
+  it "allows `function_sorter` to be set" do
+    configuration = Fx::Configuration.new
+    sorter = ->(functions) { functions.reverse }
+
+    configuration.function_sorter = sorter
+
+    expect(configuration.function_sorter).to eq(sorter)
+  end
 end


### PR DESCRIPTION
- Add config.function_sorter to allow custom function ordering
  in schema.rb
- Any callable responding to .call(functions) can be assigned
  to control the order functions are written during schema dump
- Defaults to nil (preserves existing database order)

---

/cc @mhenrixon -- this provides the hook you need from #197.