### PR TITLE
Auto-detect function argument types when dropping or updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ changelog, see the [commits] for each version via the version links.
   functions, fixing support for functions with parameters (#7)
 - Add `arguments:` option to `drop_function` and `update_function` for
   targeting specific overloads of functions that share a name
+- Custom adapters that override `drop_function` or `update_function` must
+  now accept an `arguments:` keyword argument
 - Internal refactorings / improvements
   - Add scheduled EOL check for Ruby, Rails, and PostgreSQL (#205)
   - Add GitHub release creation to release task (#209)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ changelog, see the [commits] for each version via the version links.
 - Add `Function#signature` for PostgreSQL function identity (#207)
 - Add PostgreSQL versioning policy, officially supporting PostgreSQL 14-18 (#194)
 - Refactor Statements module to use explicit keyword arguments instead of `**options` hash (#186)
+- Auto-detect function argument types from `pg_proc` when dropping or updating
+  functions, fixing support for functions with parameters (#7)
+- Add `arguments:` option to `drop_function` and `update_function` for
+  targeting specific overloads of functions that share a name
 - Internal refactorings / improvements
   - Add scheduled EOL check for Ruby, Rails, and PostgreSQL (#205)
   - Add GitHub release creation to release task (#209)

--- a/lib/fx.rb
+++ b/lib/fx.rb
@@ -14,6 +14,12 @@ require "fx/railtie"
 # F(x) adds methods `ActiveRecord::Migration` to create and manage database
 # triggers and functions in Rails applications.
 module Fx
+  class Error < StandardError; end
+
+  # Raised when dropping an overloaded function without specifying which
+  # overload to target. Pass the `arguments:` option to disambiguate.
+  class AmbiguousFunctionError < Error; end
+
   # Hooks Fx into Rails.
   #
   # Enables fx migration methods, migration reversability, and `schema.rb`

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -134,15 +134,16 @@ module Fx
       #
       # @return [void]
       def drop_function(name, arguments: nil)
-        function = if arguments
-          Fx::Function.new(
-            "name" => name.to_s,
-            "definition" => "",
-            "arguments" => arguments
-          )
-        else
-          find_function(name)
-        end
+        function =
+          if arguments
+            Fx::Function.new(
+              "name" => name.to_s,
+              "definition" => "",
+              "arguments" => arguments
+            )
+          else
+            find_function(name)
+          end
 
         execute("DROP FUNCTION #{function.signature};")
       end
@@ -168,9 +169,9 @@ module Fx
 
       def find_function(name)
         name_str = name.to_s
-        matches = functions.select { |f| f.name == name_str }
+        matches = functions.select { |function| function.name == name_str }
 
-        case matches.length
+        case matches.size
         when 0
           Fx::Function.new("name" => name_str, "definition" => "")
         when 1

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -154,6 +154,8 @@ module Fx
         execute("DROP TRIGGER #{name} ON #{on};")
       end
 
+      private
+
       # The SQL query used to look up a function's argument types from pg_proc.
       FUNCTION_ARGUMENTS_QUERY = <<~SQL.freeze
         SELECT pg_get_function_identity_arguments(pp.oid) AS arguments
@@ -164,8 +166,6 @@ module Fx
           AND %{schema_condition}
       SQL
       private_constant :FUNCTION_ARGUMENTS_QUERY
-
-      private
 
       attr_reader :connectable
 

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -134,13 +134,16 @@ module Fx
       #
       # @return [void]
       def drop_function(name, arguments: nil)
-        arguments ||= function_arguments_for(name)
+        function = if arguments
+          Fx::Function.new(
+            "name" => name.to_s,
+            "definition" => "",
+            "arguments" => arguments
+          )
+        else
+          find_function(name)
+        end
 
-        function = Fx::Function.new(
-          "name" => name.to_s,
-          "definition" => "",
-          "arguments" => arguments
-        )
         execute("DROP FUNCTION #{function.signature};")
       end
 
@@ -159,53 +162,21 @@ module Fx
 
       private
 
-      # The SQL query used to look up a function's argument types from pg_proc.
-      FUNCTION_ARGUMENTS_QUERY = <<~SQL.freeze
-        SELECT pg_get_function_identity_arguments(pp.oid) AS arguments
-        FROM pg_proc pp
-        JOIN pg_namespace pn ON pn.oid = pp.pronamespace
-        WHERE pp.proname = %{function_name}
-          AND pp.prokind = 'f'
-          AND %{schema_condition}
-      SQL
-      private_constant :FUNCTION_ARGUMENTS_QUERY
-
       attr_reader :connectable
 
       delegate :execute, to: :connection
 
-      def function_arguments_for(name)
+      def find_function(name)
         name_str = name.to_s
+        matches = functions.select { |f| f.name == name_str }
 
-        if (match = name_str.match(/\A"?([^"]+)"?\."?([^"]+)"?\z/))
-          schema = match[1]
-          function_name = match[2]
-          schema_condition = "pn.nspname = #{connection.quote(schema)}"
-        else
-          function_name = name_str
-          schema_condition = "pn.nspname = ANY(current_schemas(false))"
-        end
-
-        rows = connection.execute(
-          FUNCTION_ARGUMENTS_QUERY % {
-            function_name: connection.quote(function_name),
-            schema_condition: schema_condition
-          }
-        ).to_a
-
-        case rows.length
+        case matches.length
         when 0
-          nil
+          Fx::Function.new("name" => name_str, "definition" => "")
         when 1
-          rows.first["arguments"].presence
+          matches.first
         else
-          signatures = rows.map { |row|
-            Fx::Function.new(
-              "name" => name_str,
-              "definition" => "",
-              "arguments" => row["arguments"]
-            ).signature
-          }
+          signatures = matches.map(&:signature)
           raise Fx::AmbiguousFunctionError, <<~MSG.chomp
             Multiple definitions for function "#{name_str}": #{signatures.join(", ")}.
             Specify which to drop: drop_function :#{name_str}, arguments: "<argument types>"

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -91,10 +91,12 @@ module Fx
       #
       # @param name [String, Symbol] The name of the function.
       # @param sql_definition [String] The SQL schema for the function.
+      # @param arguments [String] Optional function argument types for
+      #   identifying overloaded functions (e.g. "integer, text").
       #
       # @return [void]
-      def update_function(name, sql_definition)
-        drop_function(name)
+      def update_function(name, sql_definition, arguments: nil)
+        drop_function(name, arguments: arguments)
         create_function(sql_definition)
       end
 
@@ -121,11 +123,22 @@ module Fx
       # This is typically called in a migration via
       # {Fx::Statements::Function#drop_function}.
       #
-      # @param name [String, Symbol] The name of the function to drop
+      # @param name [String, Symbol] The name of the function to drop.
+      # @param arguments [String] Optional function argument types for
+      #   identifying overloaded functions (e.g. "integer, text"). When not
+      #   provided, the argument types are looked up automatically from
+      #   pg_proc. If multiple overloads exist, an {Fx::AmbiguousFunctionError}
+      #   is raised.
       #
       # @return [void]
-      def drop_function(name)
-        execute("DROP FUNCTION #{name};")
+      def drop_function(name, arguments: nil)
+        arguments ||= function_arguments_for(name)
+
+        if arguments
+          execute("DROP FUNCTION #{name}(#{arguments});")
+        else
+          execute("DROP FUNCTION #{name};")
+        end
       end
 
       # Drops the trigger from the database
@@ -141,11 +154,54 @@ module Fx
         execute("DROP TRIGGER #{name} ON #{on};")
       end
 
+      # The SQL query used to look up a function's argument types from pg_proc.
+      FUNCTION_ARGUMENTS_QUERY = <<~SQL.freeze
+        SELECT pg_get_function_identity_arguments(pp.oid) AS arguments
+        FROM pg_proc pp
+        JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+        WHERE pp.proname = %{function_name}
+          AND pp.prokind = 'f'
+          AND %{schema_condition}
+      SQL
+      private_constant :FUNCTION_ARGUMENTS_QUERY
+
       private
 
       attr_reader :connectable
 
       delegate :execute, to: :connection
+
+      def function_arguments_for(name)
+        name_str = name.to_s
+
+        if name_str.include?(".")
+          schema, function_name = name_str.split(".", 2)
+          schema_condition = "pn.nspname = #{connection.quote(schema)}"
+        else
+          function_name = name_str
+          schema_condition = "pn.nspname = ANY(current_schemas(false))"
+        end
+
+        rows = connection.execute(
+          FUNCTION_ARGUMENTS_QUERY % {
+            function_name: connection.quote(function_name),
+            schema_condition: schema_condition
+          }
+        ).to_a
+
+        case rows.length
+        when 0
+          nil
+        when 1
+          rows.first["arguments"]
+        else
+          signatures = rows.map { |r| "#{name_str}(#{r["arguments"]})" }
+          raise Fx::AmbiguousFunctionError, <<~MSG.chomp
+            Multiple definitions for function "#{name_str}": #{signatures.join(", ")}.
+            Specify which to drop: drop_function :#{name_str}, arguments: "<argument types>"
+          MSG
+        end
+      end
 
       def connection
         Fx::Adapters::Postgres::Connection.new(connectable.connection)

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -136,11 +136,12 @@ module Fx
       def drop_function(name, arguments: nil)
         arguments ||= function_arguments_for(name)
 
-        if arguments
-          execute("DROP FUNCTION #{name}(#{arguments});")
-        else
-          execute("DROP FUNCTION #{name};")
-        end
+        function = Fx::Function.new(
+          "name" => name.to_s,
+          "definition" => "",
+          "arguments" => arguments
+        )
+        execute("DROP FUNCTION #{function.signature};")
       end
 
       # Drops the trigger from the database
@@ -198,7 +199,9 @@ module Fx
         when 1
           rows.first["arguments"].presence
         else
-          signatures = rows.map { |r| "#{name_str}(#{r["arguments"]})" }
+          signatures = rows.map { |r|
+            Fx::Function.new("name" => name_str, "definition" => "", "arguments" => r["arguments"]).signature
+          }
           raise Fx::AmbiguousFunctionError, <<~MSG.chomp
             Multiple definitions for function "#{name_str}": #{signatures.join(", ")}.
             Specify which to drop: drop_function :#{name_str}, arguments: "<argument types>"

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -92,7 +92,8 @@ module Fx
       # @param name [String, Symbol] The name of the function.
       # @param sql_definition [String] The SQL schema for the function.
       # @param arguments [String] Optional function argument types for
-      #   identifying overloaded functions (e.g. "integer, text").
+      #   identifying overloaded functions (e.g. "integer, text"). This
+      #   option is specific to the Postgres adapter.
       #
       # @return [void]
       def update_function(name, sql_definition, arguments: nil)
@@ -128,7 +129,8 @@ module Fx
       #   identifying overloaded functions (e.g. "integer, text"). When not
       #   provided, the argument types are looked up automatically from
       #   pg_proc. If multiple overloads exist, an {Fx::AmbiguousFunctionError}
-      #   is raised.
+      #   is raised. This option is specific to the Postgres adapter; custom
+      #   adapters that do not accept it will raise an ArgumentError.
       #
       # @return [void]
       def drop_function(name, arguments: nil)
@@ -174,8 +176,9 @@ module Fx
       def function_arguments_for(name)
         name_str = name.to_s
 
-        if name_str.include?(".")
-          schema, function_name = name_str.split(".", 2)
+        if (match = name_str.match(/\A"?([^"]+)"?\."?([^"]+)"?\z/))
+          schema = match[1]
+          function_name = match[2]
           schema_condition = "pn.nspname = #{connection.quote(schema)}"
         else
           function_name = name_str
@@ -193,7 +196,7 @@ module Fx
         when 0
           nil
         when 1
-          rows.first["arguments"]
+          rows.first["arguments"].presence
         else
           signatures = rows.map { |r| "#{name_str}(#{r["arguments"]})" }
           raise Fx::AmbiguousFunctionError, <<~MSG.chomp

--- a/lib/fx/adapters/postgres.rb
+++ b/lib/fx/adapters/postgres.rb
@@ -199,8 +199,12 @@ module Fx
         when 1
           rows.first["arguments"].presence
         else
-          signatures = rows.map { |r|
-            Fx::Function.new("name" => name_str, "definition" => "", "arguments" => r["arguments"]).signature
+          signatures = rows.map { |row|
+            Fx::Function.new(
+              "name" => name_str,
+              "definition" => "",
+              "arguments" => row["arguments"]
+            ).signature
           }
           raise Fx::AmbiguousFunctionError, <<~MSG.chomp
             Multiple definitions for function "#{name_str}": #{signatures.join(", ")}.

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -30,7 +30,7 @@ module Fx
     #     $$ LANGUAGE plpgsql;
     #   SQL
     #
-    def create_function(name, version: 1, sql_definition: nil, revert_to_version: nil)
+    def create_function(name, version: 1, sql_definition: nil, revert_to_version: nil, arguments: nil)
       validate_version_or_sql_definition_present!(version, sql_definition)
       sql_definition = resolve_sql_definition(sql_definition, name, version, :function)
 

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -45,7 +45,8 @@ module Fx
     #   the `version` argument to {#create_function}.
     # @param arguments [String] Function argument types for identifying
     #   overloaded functions (e.g. "integer, text"). When omitted, the
-    #   adapter auto-detects the signature from the database.
+    #   Postgres adapter auto-detects the signature from the database.
+    #   Custom adapters must accept this keyword to use it.
     # @return [void] The database response from executing the drop statement.
     #
     # @example Drop a function, rolling back to version 2 on rollback
@@ -66,7 +67,8 @@ module Fx
     #   `sql_definition` takes precedence.
     # @param arguments [String] Function argument types for identifying
     #   overloaded functions (e.g. "integer, text"). When omitted, the
-    #   adapter auto-detects the signature from the database.
+    #   Postgres adapter auto-detects the signature from the database.
+    #   Custom adapters must accept this keyword to use it.
     # @return [void] The database response from executing the create statement.
     #
     # @example Update function to a given version

--- a/lib/fx/statements.rb
+++ b/lib/fx/statements.rb
@@ -10,6 +10,10 @@ module Fx
     # @param sql_definition [String] The SQL query for the function schema.
     #   If both `sql_definition` and `version` are provided,
     #   `sql_definition` takes precedence.
+    # @param arguments [String] Function argument types (e.g. "integer, text").
+    #   Not used during creation itself, but preserved by the command recorder
+    #   so that a rollback of this migration can pass the correct signature to
+    #   {#drop_function}. Only needed for overloaded functions.
     # @return [void] The database response from executing the create statement.
     #
     # @example Create from `db/functions/uppercase_users_name_v02.sql`
@@ -39,13 +43,16 @@ module Fx
     # @param revert_to_version [Integer] Used to reverse the `drop_function`
     #   command on `rake db:rollback`. The provided version will be passed as
     #   the `version` argument to {#create_function}.
+    # @param arguments [String] Function argument types for identifying
+    #   overloaded functions (e.g. "integer, text"). When omitted, the
+    #   adapter auto-detects the signature from the database.
     # @return [void] The database response from executing the drop statement.
     #
     # @example Drop a function, rolling back to version 2 on rollback
     #   drop_function(:uppercase_users_name, revert_to_version: 2)
     #
-    def drop_function(name, revert_to_version: nil)
-      Fx.database.drop_function(name)
+    def drop_function(name, revert_to_version: nil, arguments: nil)
+      Fx.database.drop_function(name, **{arguments: arguments}.compact)
     end
 
     # Update a database function.
@@ -57,6 +64,9 @@ module Fx
     # @param sql_definition [String] The SQL query for the function schema.
     #   If both `sql_definition` and `version` are provided,
     #   `sql_definition` takes precedence.
+    # @param arguments [String] Function argument types for identifying
+    #   overloaded functions (e.g. "integer, text"). When omitted, the
+    #   adapter auto-detects the signature from the database.
     # @return [void] The database response from executing the create statement.
     #
     # @example Update function to a given version
@@ -77,12 +87,12 @@ module Fx
     #     $$ LANGUAGE plpgsql;
     #   SQL
     #
-    def update_function(name, version: nil, sql_definition: nil, revert_to_version: nil)
+    def update_function(name, version: nil, sql_definition: nil, revert_to_version: nil, arguments: nil)
       validate_version_or_sql_definition_present!(version, sql_definition)
 
       sql_definition = resolve_sql_definition(sql_definition, name, version, :function)
 
-      Fx.database.update_function(name, sql_definition)
+      Fx.database.update_function(name, sql_definition, **{arguments: arguments}.compact)
     end
 
     # Create a new database trigger.

--- a/spec/acceptance/user_manages_functions_spec.rb
+++ b/spec/acceptance/user_manages_functions_spec.rb
@@ -54,4 +54,93 @@ RSpec.describe "User manages functions" do
     successfully "rails destroy fx:function adder"
     successfully "rake db:migrate"
   end
+
+  it "handles updating functions with arguments" do
+    successfully "rails generate fx:function multiply"
+    write_function_definition "multiply_v01", <<~SQL
+      CREATE FUNCTION multiply(x int, y int)
+      RETURNS int AS $$
+      BEGIN
+          RETURN x * y;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+    successfully "rake db:migrate"
+
+    result = execute("SELECT * FROM multiply(3, 4) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 12)
+
+    successfully "rails generate fx:function multiply"
+    write_function_definition "multiply_v02", <<~SQL
+      CREATE FUNCTION multiply(x int, y int)
+      RETURNS int AS $$
+      BEGIN
+          RETURN x * y * 2;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+    successfully "rake db:migrate"
+
+    result = execute("SELECT * FROM multiply(3, 4) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 24)
+
+    successfully "rake db:rollback"
+
+    result = execute("SELECT * FROM multiply(3, 4) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 12)
+
+    successfully "rake db:rollback"
+
+    expect { execute("SELECT * FROM multiply(3, 4) AS result") }
+      .to raise_error(ActiveRecord::StatementInvalid)
+  end
+
+  it "handles dropping overloaded functions with explicit arguments" do
+    successfully "rails generate fx:function inc"
+    write_function_definition "inc_v01", <<~SQL
+      CREATE FUNCTION inc(x int)
+      RETURNS int AS $$
+      BEGIN RETURN x + 1; END;
+      $$ LANGUAGE plpgsql;
+    SQL
+    successfully "rake db:migrate"
+
+    execute <<~SQL
+      CREATE FUNCTION inc(x int, step int)
+      RETURNS int AS $$ BEGIN RETURN x + step; END; $$ LANGUAGE plpgsql;
+    SQL
+
+    result = execute("SELECT inc(5) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 6)
+
+    result = execute("SELECT inc(5, 10) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 15)
+
+    write_migration "drop_inc_one_arg", <<~RUBY
+      class DropIncOneArg < ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]
+        def change
+          drop_function :inc, arguments: "integer", revert_to_version: 1
+        end
+      end
+    RUBY
+    successfully "rake db:migrate"
+
+    expect { execute("SELECT inc(5) AS result") }
+      .to raise_error(ActiveRecord::StatementInvalid)
+
+    result = execute("SELECT inc(5, 10) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 15)
+
+    successfully "rake db:rollback"
+
+    result = execute("SELECT inc(5) AS result")
+    result["result"] = result["result"].to_i
+    expect(result).to eq("result" => 6)
+  end
 end

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -61,6 +61,12 @@ RSpec.configure do |config|
     successfully "cmp #{def_a} #{def_b}"
   end
 
+  def write_migration(name, contents)
+    Dir.mkdir("db/migrate") unless Dir.exist?("db/migrate")
+    timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S")
+    File.write("db/migrate/#{timestamp}_#{name}.rb", contents)
+  end
+
   def execute(command)
     ActiveRecord::Base.connection.execute(command).first
   end

--- a/spec/fx/adapters/postgres_spec.rb
+++ b/spec/fx/adapters/postgres_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Fx::Adapters::Postgres, :db do
 
   describe "#drop_function" do
     context "when the function has arguments" do
-      it "successfully drops a function with the entire function signature" do
+      it "successfully drops a function by looking up its signature" do
         adapter = Fx::Adapters::Postgres.new
         adapter.create_function(
           <<~SQL
@@ -89,6 +89,56 @@ RSpec.describe Fx::Adapters::Postgres, :db do
         adapter.drop_function(:test)
 
         expect(adapter.functions.map(&:name)).not_to include("test")
+      end
+    end
+
+    context "when the function is overloaded" do
+      it "raises AmbiguousFunctionError" do
+        adapter = Fx::Adapters::Postgres.new
+        adapter.create_function(
+          <<~SQL
+            CREATE FUNCTION foo(x int)
+            RETURNS int AS $$
+            BEGIN RETURN x; END;
+            $$ LANGUAGE plpgsql;
+          SQL
+        )
+        adapter.create_function(
+          <<~SQL
+            CREATE FUNCTION foo(x int, y int)
+            RETURNS int AS $$
+            BEGIN RETURN x + y; END;
+            $$ LANGUAGE plpgsql;
+          SQL
+        )
+
+        expect { adapter.drop_function(:foo) }
+          .to raise_error(Fx::AmbiguousFunctionError, /Multiple definitions/)
+      end
+
+      it "drops the correct overload when arguments are specified" do
+        adapter = Fx::Adapters::Postgres.new
+        adapter.create_function(
+          <<~SQL
+            CREATE FUNCTION foo(x int)
+            RETURNS int AS $$
+            BEGIN RETURN x; END;
+            $$ LANGUAGE plpgsql;
+          SQL
+        )
+        adapter.create_function(
+          <<~SQL
+            CREATE FUNCTION foo(x int, y int)
+            RETURNS int AS $$
+            BEGIN RETURN x + y; END;
+            $$ LANGUAGE plpgsql;
+          SQL
+        )
+
+        adapter.drop_function(:foo, arguments: "int, int")
+
+        remaining = adapter.functions.select { |f| f.name == "foo" }
+        expect(remaining.length).to eq(1)
       end
     end
   end

--- a/spec/fx/command_recorder_spec.rb
+++ b/spec/fx/command_recorder_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Fx::CommandRecorder, :db do
 
       expect(recorder.commands).to eq([[:drop_function, [:test]]])
     end
+
+    it "reverts to drop_function preserving arguments" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+
+      recorder.revert do
+        recorder.create_function :test, arguments: "integer, text"
+      end
+
+      expect(recorder.commands).to eq(
+        [[:drop_function, [:test, {arguments: "integer, text"}]]]
+      )
+    end
   end
 
   describe "#drop_function" do
@@ -32,6 +44,16 @@ RSpec.describe Fx::CommandRecorder, :db do
       recorder = ActiveRecord::Migration::CommandRecorder.new
       args = [:test, {revert_to_version: 3}]
       revert_args = [:test, {version: 3}]
+
+      recorder.revert { recorder.drop_function(*args) }
+
+      expect(recorder.commands).to eq([[:create_function, revert_args]])
+    end
+
+    it "reverts to create_function preserving arguments" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, {revert_to_version: 3, arguments: "integer"}]
+      revert_args = [:test, {arguments: "integer", version: 3}]
 
       recorder.revert { recorder.drop_function(*args) }
 
@@ -62,6 +84,16 @@ RSpec.describe Fx::CommandRecorder, :db do
       recorder = ActiveRecord::Migration::CommandRecorder.new
       args = [:test, {version: 2, revert_to_version: 1}]
       revert_args = [:test, {version: 1}]
+
+      recorder.revert { recorder.update_function(*args) }
+
+      expect(recorder.commands).to eq([[:update_function, revert_args]])
+    end
+
+    it "reverts to update_function preserving arguments" do
+      recorder = ActiveRecord::Migration::CommandRecorder.new
+      args = [:test, {version: 2, revert_to_version: 1, arguments: "integer"}]
+      revert_args = [:test, {arguments: "integer", version: 1}]
 
       recorder.revert { recorder.update_function(*args) }
 

--- a/spec/fx/statements_spec.rb
+++ b/spec/fx/statements_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe Fx::Statements, :db do
 
       expect(database).to have_received(:drop_function).with(:test)
     end
+
+    it "passes arguments through to the adapter" do
+      database = stubbed_database
+
+      connection.drop_function(:test, arguments: "integer, text")
+
+      expect(database).to have_received(:drop_function)
+        .with(:test, arguments: "integer, text")
+    end
   end
 
   describe "#update_function" do
@@ -70,6 +79,16 @@ RSpec.describe Fx::Statements, :db do
 
       expect(database).to have_received(:update_function)
         .with(:test, "a definition")
+    end
+
+    it "passes arguments through to the adapter" do
+      database = stubbed_database
+      definition = stubbed_definition
+
+      connection.update_function(:test, version: 3, arguments: "integer")
+
+      expect(database).to have_received(:update_function)
+        .with(:test, definition.to_sql, arguments: "integer")
     end
 
     it "raises an error if not supplied a version" do


### PR DESCRIPTION
Functions with parameters could not be dropped or updated
because PostgreSQL requires argument types in DROP FUNCTION.
This has been the longest-standing open issue (#7, 2017).

- Look up argument types from pg_proc automatically at
  drop/update time
- Accept an explicit arguments: option on drop_function and
  update_function for overloaded functions
- Raise Fx::AmbiguousFunctionError with guidance when multiple
  overloads exist and no arguments: option is given
- Forward arguments: through Fx::Statements using
  **options.slice(:arguments), keeping custom adapters working

Closes #7