### PR TITLE
Add config.trigger_sorter for schema dumper

### DIFF
--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -23,10 +23,19 @@ module Fx
     # @return [#call, nil] Function sorter
     attr_accessor :function_sorter
 
+    # A callable that sorts triggers before they are dumped to schema.rb.
+    # Must respond to `.call(triggers)` and return a sorted array of
+    # {Fx::Trigger} objects.
+    #
+    # Defaults to nil (no sorting, preserves database order).
+    # @return [#call, nil] Trigger sorter
+    attr_accessor :trigger_sorter
+
     def initialize
       @database = Fx::Adapters::Postgres.new
       @dump_functions_at_beginning_of_schema = false
       @function_sorter = nil
+      @trigger_sorter = nil
     end
   end
 end

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -31,9 +31,17 @@ module Fx
     end
 
     def triggers(stream)
-      Fx.database.triggers.each do |trigger|
+      sorted_triggers(Fx.database.triggers).each do |trigger|
         stream.puts
         stream.puts(trigger.to_schema)
+      end
+    end
+
+    def sorted_triggers(triggers)
+      if (trigger_sorter = Fx.configuration.trigger_sorter)
+        trigger_sorter.call(triggers)
+      else
+        triggers
       end
     end
   end

--- a/spec/fx/configuration_spec.rb
+++ b/spec/fx/configuration_spec.rb
@@ -44,4 +44,19 @@ RSpec.describe Fx::Configuration do
 
     expect(configuration.function_sorter).to eq(sorter)
   end
+
+  it "defaults `trigger_sorter` to nil" do
+    configuration = Fx::Configuration.new
+
+    expect(configuration.trigger_sorter).to be_nil
+  end
+
+  it "allows `trigger_sorter` to be set" do
+    configuration = Fx::Configuration.new
+    sorter = ->(triggers) { triggers.reverse }
+
+    configuration.trigger_sorter = sorter
+
+    expect(configuration.trigger_sorter).to eq(sorter)
+  end
 end


### PR DESCRIPTION
- Add `config.trigger_sorter` to allow custom trigger ordering in schema.rb, mirroring the existing `config.function_sorter`