### PR TITLE
Document adapter subclass pattern for custom schema dump ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ column value instead of a plain string.
 
 By default, functions and triggers are dumped to `schema.rb` in the order
 returned by the database. If you need a specific ordering (e.g., alphabetical
-for deterministic diffs), subclass the adapter:
+for deterministic diffs), subclass the adapter and override `#functions` or
+`#triggers`. These methods are part of the adapter's public API and will remain
+stable across releases:
 
 ```ruby
 # config/initializers/fx.rb

--- a/README.md
+++ b/README.md
@@ -107,6 +107,33 @@ end
 That's how you tell Rails to use the default as a literal SQL for the default
 column value instead of a plain string.
 
+## Customizing Schema Dump Order
+
+By default, functions and triggers are dumped to `schema.rb` in the order
+returned by the database. If you need a specific ordering (e.g., alphabetical
+for deterministic diffs), subclass the adapter:
+
+```ruby
+# config/initializers/fx.rb
+class SortedPostgresAdapter < Fx::Adapters::Postgres
+  def functions
+    super.sort_by(&:name)
+  end
+
+  def triggers
+    super.sort_by(&:name)
+  end
+end
+
+Fx.configure do |config|
+  config.database = SortedPostgresAdapter.new
+end
+```
+
+The same approach works for more advanced ordering. For example, if your
+functions depend on each other and need to be dumped in dependency order, you
+could use Ruby's built-in `TSort` to topologically sort them.
+
 ## Plugins/Adapters
 
 - [MySQL](https://github.com/f-mer/fx-adapters-mysql/)


### PR DESCRIPTION
Users who need custom function/trigger ordering in schema.rb
(alphabetical, topological, dependency-based) can already achieve this
by subclassing the adapter -- no new API needed. Document this pattern
and mention Ruby's TSort for topological sorting of dependent functions.

This approach uses the existing adapter extension point that F(x) was
designed around. Users override #functions and #triggers in a subclass.

An alternative considered was adding config.function_sorter /
config.trigger_sorter options (#200, #210), but the adapter subclass
pattern is more flexible and avoids new API surface.