### PR TITLE
Drop EOL Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "4.0"]
+        ruby: ["3.3", "4.0"]
         rails: ["7.2", "8.1"]
         postgres: ["14", "18"]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ changelog, see the [commits] for each version via the version links.
 
 [Unreleased]: https://github.com/teoljungberg/fx/compare/v0.10.2..HEAD
 
-- Drop EOL Ruby 3.2
+- Drop EOL Ruby 3.2 (#212)
 - Add `Function#signature` for PostgreSQL function identity (#207)
 - Add PostgreSQL versioning policy, officially supporting PostgreSQL 14-18 (#194)
 - Refactor Statements module to use explicit keyword arguments instead of `**options` hash (#186)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ changelog, see the [commits] for each version via the version links.
 
 [Unreleased]: https://github.com/teoljungberg/fx/compare/v0.10.2..HEAD
 
+- Drop EOL Ruby 3.2
 - Add `Function#signature` for PostgreSQL function identity (#207)
 - Add PostgreSQL versioning policy, officially supporting PostgreSQL 14-18 (#194)
 - Refactor Statements module to use explicit keyword arguments instead of `**options` hash (#186)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ could use Ruby's built-in `TSort` to topologically sort them.
 F(x) follows the maintenance policies of Ruby, Rails, and PostgreSQL, supporting
 versions within their official maintenance windows.
 
-**Ruby:** 3.2+ ([maintenance branches])
+**Ruby:** 3.3+ ([maintenance branches])
 
 **Rails:** 7.2, 8.0, 8.1 ([maintenance policy])
 

--- a/fx.gemspec
+++ b/fx.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.2"
   spec.add_dependency "railties", ">= 7.2"
 
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 end


### PR DESCRIPTION
Ruby 3.2 reached EOL on 2025-03-31.

Bumps the minimum Ruby version to 3.3 in the gemspec, CI matrix, and README.

Closes #204