### PR TITLE
Add CI summary job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,12 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake
+
+  ci:
+    name: CI
+    needs: [tests]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          [[ "${{ needs.tests.result }}" == "success" ]] || exit 1


### PR DESCRIPTION
Branch protection requires named status checks, but the tests job uses a
matrix that produces several distinct check names that shift whenever
the matrix changes (Ruby, Rails, and Postgres versions get added or
dropped).

Aggregating the matrix into a single CI check lets branch protection pin
to one stable name and survive matrix edits without a follow-up
infrastructure change every time.