### PR TITLE
Follow PostgreSQL supported versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,17 @@ jobs:
       matrix:
         ruby: ["3.3", "4.0"]
         rails: ["7.2", "8.1"]
-        postgres: ["14", "18"]
+        postgres: ["14", "15", "16", "17", "18"]
         include:
           - ruby: "4.0"
             rails: "main"
             postgres: "18"
+            allow-failure: true
+          # Upcoming PostgreSQL release (not yet GA). Non-blocking readiness
+          # check; the `postgres:19` image becomes available at its GA.
+          - ruby: "4.0"
+            rails: "8.1"
+            postgres: "19"
             allow-failure: true
 
     continue-on-error: ${{ matrix.allow-failure || false }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ruby: ["3.3", "4.0"]
         rails: ["7.2", "8.1"]
-        postgres: ["14", "15", "16", "17", "18"]
+        postgres: ["14", "18"]
         include:
           - ruby: "4.0"
             rails: "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
             rails: "main"
             postgres: "18"
             allow-failure: true
-          # Upcoming PostgreSQL release (not yet GA). Non-blocking readiness
-          # check; the `postgres:19` image becomes available at its GA.
           - ruby: "4.0"
             rails: "8.1"
             postgres: "19"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ changelog, see the [commits] for each version via the version links.
 
 [commits]: https://github.com/teoljungberg/fx/commits/master
 
+## [Unreleased]
+
+[Unreleased]: https://github.com/teoljungberg/fx/compare/v0.11.0...master
+
+- Internal refactorings / improvements
+  - Test the full range of supported PostgreSQL versions (14-18) in CI
+  - Add a non-blocking CI job for the upcoming PostgreSQL 19 release
+
 ## [0.11.0]
 
 [0.11.0]: https://github.com/teoljungberg/fx/compare/v0.10.2...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ changelog, see the [commits] for each version via the version links.
 [Unreleased]: https://github.com/teoljungberg/fx/compare/v0.11.0...master
 
 - Internal refactorings / improvements
-  - Test the full range of supported PostgreSQL versions (14-18) in CI
   - Add a non-blocking CI job for the upcoming PostgreSQL 19 release
 
 ## [0.11.0]


### PR DESCRIPTION
PostgreSQL's versioning policy supports the five most recent major releases. Add a non-blocking CI job for the upcoming PostgreSQL 19 release so we're ready ahead of its GA, mirroring the existing rails:main readiness job.

- Add a postgres 19 job marked allow-failure; the `postgres:19` image activates at its GA
- Keep the boundary postgres matrix `[14, 18]` for lower maintenance